### PR TITLE
Optimizing initialization of evaluators and rule

### DIFF
--- a/src/recordlinker/linking/link.py
+++ b/src/recordlinker/linking/link.py
@@ -13,7 +13,6 @@ from opentelemetry import trace
 from sqlalchemy import orm
 
 from recordlinker import models
-from recordlinker import utils
 from recordlinker.linking import matchers
 
 from . import mpi_service
@@ -87,10 +86,9 @@ def compare(record: models.PIIRecord, patient: models.Patient, algorithm_pass: m
     Compare the incoming record to the linked patient
     """
     # all the functions used for comparison
-    #TODO: optimization: bind functions earlier in the stack to avoid multiple unnecessary calls
-    funcs: dict[models.Feature, matchers.FEATURE_COMPARE_FUNC] = utils.bind_functions(algorithm_pass.evaluators)
+    funcs: dict[models.Feature, matchers.FEATURE_COMPARE_FUNC] = algorithm_pass.bound_evaluators()
     # a function to determine a match based on the comparison results
-    matching_rule: matchers.MATCH_RULE_FUNC = utils.str_to_callable(algorithm_pass.rule)
+    matching_rule: matchers.MATCH_RULE_FUNC = algorithm_pass.bound_rule()
     # # keyword arguments to pass to comparison functions and matching rule
     kwargs: dict[typing.Any, typing.Any] = algorithm_pass.kwargs
 

--- a/src/recordlinker/linking/link.py
+++ b/src/recordlinker/linking/link.py
@@ -86,7 +86,7 @@ def compare(record: models.PIIRecord, patient: models.Patient, algorithm_pass: m
     Compare the incoming record to the linked patient
     """
     # all the functions used for comparison
-    funcs: dict[models.Feature, matchers.FEATURE_COMPARE_FUNC] = algorithm_pass.bound_evaluators()
+    funcs: dict[str, matchers.FEATURE_COMPARE_FUNC] = algorithm_pass.bound_evaluators()
     # a function to determine a match based on the comparison results
     matching_rule: matchers.MATCH_RULE_FUNC = algorithm_pass.bound_rule()
     # # keyword arguments to pass to comparison functions and matching rule
@@ -94,6 +94,7 @@ def compare(record: models.PIIRecord, patient: models.Patient, algorithm_pass: m
 
     results: list[float] = []
     for field, func in funcs.items():
+        # TODO: can we do this check earlier?
         if field not in {i.value for i in models.Feature}:
             raise ValueError(f"Invalid comparison field: {field}")
         # Evaluate the comparison function and append the result to the list

--- a/src/recordlinker/utils.py
+++ b/src/recordlinker/utils.py
@@ -55,12 +55,15 @@ def str_to_callable(val: str) -> typing.Callable:
     # Remove the "func:" prefix
     if val.startswith("func:"):
         val = val[5:]
-    # Split the string into module path and function name
-    module_path, func_name = val.rsplit(".", 1)
-    # Import the module
-    module = importlib.import_module(module_path)
-    # Get the function from the module
-    return getattr(module, func_name)
+    try:
+        # Split the string into module path and function name
+        module_path, func_name = val.rsplit(".", 1)
+        # Import the module
+        module = importlib.import_module(module_path)
+        # Get the function from the module
+        return getattr(module, func_name)
+    except Exception as e:
+        raise ValueError(f"Failed to convert string to callable: {val}") from e
 
 
 def func_to_str(func: typing.Callable) -> str:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -49,10 +49,10 @@ def test_str_to_callable():
     val = "recordlinker.linking.matchers.feature_match_exact"
     assert utils.str_to_callable(val) == matchers.feature_match_exact
     val = "recordlinker.unknown_module.unknown_function"
-    with pytest.raises(ImportError):
+    with pytest.raises(ValueError):
         utils.str_to_callable(val)
     val = "recordlinker.linking.matchers.unknown_function"
-    with pytest.raises(AttributeError):
+    with pytest.raises(ValueError):
         utils.str_to_callable(val)
 
 


### PR DESCRIPTION
## Description
Adds the `bound_evaluators` and `bound_rule` functions to the AlgorithmPass model so we can cache the binding operations for future use.

## Related Issues
This is a small optimization for features added in #72 

## Additional Notes
Binding the AlgorithmPass evaluators and rule to functions for every compare call adds overhead.  It's quicker if we just do that once for the pass, and allow all subsequent calls to reuse the bound values.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.
- [x] I have notified teammates in the review thread to build awareness.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
