### PR TITLE
add setting.db_table_prefix variable

### DIFF
--- a/src/recordlinker/config.py
+++ b/src/recordlinker/config.py
@@ -22,6 +22,10 @@ class Settings(pydantic_settings.BaseSettings):
     )
 
     db_uri: str = pydantic.Field(description="The URI for the MPI database")
+    db_table_prefix: str = pydantic.Field(
+        description="The prefix for all database tables",
+        default="",
+    )
     test_db_uri: str = pydantic.Field(
         description="The URI for the MPI database to run tests against",
         default="sqlite:///testdb.sqlite3",

--- a/src/recordlinker/models/algorithm.py
+++ b/src/recordlinker/models/algorithm.py
@@ -75,7 +75,7 @@ class AlgorithmPass(Base):
 
     id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
     algorithm_id: orm.Mapped[int] = orm.mapped_column(
-        schema.ForeignKey("algorithm.id", ondelete="CASCADE")
+        schema.ForeignKey(f"{Algorithm.__tablename__}.id", ondelete="CASCADE")
     )
     algorithm: orm.Mapped["Algorithm"] = orm.relationship(back_populates="passes")
     blocking_keys: orm.Mapped[list[str]] = orm.mapped_column(sqltypes.JSON)

--- a/src/recordlinker/models/base.py
+++ b/src/recordlinker/models/base.py
@@ -1,9 +1,19 @@
 from sqlalchemy import orm
 from sqlalchemy import types as sqltypes
 
+from recordlinker.config import settings
 
-class Base(orm.DeclarativeBase):
-    pass
+
+class PrefixerMeta(orm.DeclarativeMeta):
+
+    def __init__(cls, name, bases, dict_):
+        name = dict_.get("__tablename__")
+        if name:
+            cls.__tablename__ = f"{settings.db_table_prefix}{name}"
+            dict_["__tablename__"] = f"{settings.db_table_prefix}{name}"
+        return super().__init__(name, bases, dict_)
+
+Base = orm.declarative_base(metaclass=PrefixerMeta)
 
 
 def get_bigint_pk():

--- a/src/recordlinker/models/mpi.py
+++ b/src/recordlinker/models/mpi.py
@@ -39,7 +39,7 @@ class Patient(Base):
     __tablename__ = "mpi_patient"
 
     id: orm.Mapped[int] = orm.mapped_column(get_bigint_pk(), autoincrement=True, primary_key=True)
-    person_id: orm.Mapped[int] = orm.mapped_column(schema.ForeignKey("mpi_person.id"))
+    person_id: orm.Mapped[int] = orm.mapped_column(schema.ForeignKey(f"{Person.__tablename__}.id"))
     person: orm.Mapped["Person"] = orm.relationship(back_populates="patients")
     # NOTE: We're using a protected attribute here to store the data string, as we
     # want getter/setter access to the data dictionary to trigger updating the
@@ -157,7 +157,7 @@ class BlockingValue(Base):
     )
 
     id: orm.Mapped[int] = orm.mapped_column(get_bigint_pk(), autoincrement=True, primary_key=True)
-    patient_id: orm.Mapped[int] = orm.mapped_column(schema.ForeignKey("mpi_patient.id"))
+    patient_id: orm.Mapped[int] = orm.mapped_column(schema.ForeignKey(f"{Patient.__tablename__}.id"))
     patient: orm.Mapped["Patient"] = orm.relationship(back_populates="blocking_values")
     blockingkey: orm.Mapped[int] = orm.mapped_column(sqltypes.SmallInteger)
     value: orm.Mapped[str] = orm.mapped_column(sqltypes.String(BLOCKING_VALUE_MAX_LENGTH))


### PR DESCRIPTION
## Description
Adding `setting.db_table_prefix` so customers can optionally change all the table names with a prefix.

## Additional Notes
Allowing customers to use an existing database for storing the MPI tables comes at a risk of not knowing what existing tables the customer might have in their database.  To guarantee that the customer doesn't have any naming conflicts with the tables created by Record Linker, we can allow for an optional prefix ENV variable given them the opportunity to override the table names.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
