### PR TITLE
endpoints to update person cluster on patient

### DIFF
--- a/docs/mpi-design.md
+++ b/docs/mpi-design.md
@@ -25,21 +25,22 @@ The following diagram illustrates the relationships between the `Person`, `Patie
 ```mermaid
 erDiagram
     Person {
-        bigint id PK "Primary Key"
-        uuid internal_id "Internal UUID"
+        bigint id PK "Primary Key (auto-generated)"
+        uuid reference_id "Reference UUID (auto-generated)"
     }
 
     Patient {
-        bigint id PK "Primary Key"
+        bigint id PK "Primary Key (auto-generated)"
         bigint person_id FK "Foreign Key to Person"
-        json data "Patient Data"
+        json data "Patient Data JSON Object"
+        uuid reference_id "Reference UUID (auto-generated)"
         string external_patient_id "External Patient ID"
         string external_person_id "External Person ID"
         string external_person_source "External Person Source"
     }
 
     BlockingValue {
-        bigint id PK "Primary Key"
+        bigint id PK "Primary Key (auto-generated)"
         bigint patient_id FK "Foreign Key to Patient"
         smallint blockingkey "Blocking Key Type"
         string value "Blocking Value"

--- a/src/recordlinker/linking/mpi_service.py
+++ b/src/recordlinker/linking/mpi_service.py
@@ -6,8 +6,10 @@ This module provides the data access functions to the MPI tables
 """
 
 import typing
+import uuid
 
 from sqlalchemy import orm
+from sqlalchemy import select
 from sqlalchemy.sql import expression
 
 from recordlinker import models
@@ -29,7 +31,7 @@ def get_block_data(
     # has a matching Blocking Value for all the Blocking Keys, then it
     # is considered a match.
     for idx, key_id in enumerate(algorithm_pass.blocking_keys):
-        #get the BlockingKey obj from the id
+        # get the BlockingKey obj from the id
         if not hasattr(models.BlockingKey, key_id):
             raise ValueError(f"No BlockingKey with id {id} found.")
         key = getattr(models.BlockingKey, key_id)
@@ -109,3 +111,39 @@ def insert_blocking_keys(
     if commit:
         session.commit()
     return values
+
+
+def get_patient_by_reference_id(
+    session: orm.Session, reference_id: uuid.UUID
+) -> models.Patient | None:
+    """
+    Retrieve the Patient by their reference id
+    """
+    query = select(models.Patient).where(models.Patient.reference_id == reference_id)
+    return session.scalar(query)
+
+
+def get_person_by_reference_id(
+    session: orm.Session, reference_id: uuid.UUID
+) -> models.Person | None:
+    """
+    Retrieve the Person by their reference id
+    """
+    query = select(models.Person).where(models.Person.reference_id == reference_id)
+    return session.scalar(query)
+
+
+def update_person_cluster(
+    session: orm.Session,
+    patient: models.Patient,
+    person: models.Person | None = None,
+    commit: bool = True,
+) -> models.Person:
+    """
+    Update the cluster for a given patient.
+    """
+    patient.person = person or models.Person()
+
+    if commit:
+        session.commit()
+    return patient.person

--- a/src/recordlinker/linking/mpi_service.py
+++ b/src/recordlinker/linking/mpi_service.py
@@ -143,6 +143,7 @@ def update_person_cluster(
     Update the cluster for a given patient.
     """
     patient.person = person or models.Person()
+    session.flush()
 
     if commit:
         session.commit()

--- a/src/recordlinker/main.py
+++ b/src/recordlinker/main.py
@@ -23,6 +23,7 @@ from recordlinker.database import get_session
 from recordlinker.linking import algorithm_service
 from recordlinker.linking import link
 from recordlinker.routes.algorithm_router import router as algorithm_router
+from recordlinker.routes.patient_router import router as patient_router
 
 # Instantiate FastAPI via DIBBs' BaseService class
 app = BaseService(
@@ -35,6 +36,7 @@ app = BaseService(
 app.add_middleware(middleware.CorrelationIdMiddleware)
 app.add_middleware(middleware.AccessLogMiddleware)
 app.include_router(algorithm_router, prefix="/algorithm", tags=["algorithm"])
+app.include_router(patient_router, prefix="/patient", tags=["patient"])
 
 
 # Request and response models

--- a/src/recordlinker/models/mpi.py
+++ b/src/recordlinker/models/mpi.py
@@ -19,7 +19,7 @@ class Person(Base):
     __tablename__ = "mpi_person"
 
     id: orm.Mapped[int] = orm.mapped_column(get_bigint_pk(), autoincrement=True, primary_key=True)
-    reference_id: orm.Mapped[uuid.UUID] = orm.mapped_column(default=uuid.uuid4)
+    reference_id: orm.Mapped[uuid.UUID] = orm.mapped_column(default=uuid.uuid4, unique=True, index=True)
     patients: orm.Mapped[list["Patient"]] = orm.relationship(back_populates="person")
 
     def __hash__(self):
@@ -50,7 +50,7 @@ class Patient(Base):
     external_person_id: orm.Mapped[str] = orm.mapped_column(sqltypes.String(255), nullable=True)
     external_person_source: orm.Mapped[str] = orm.mapped_column(sqltypes.String(100), nullable=True)
     blocking_values: orm.Mapped[list["BlockingValue"]] = orm.relationship(back_populates="patient")
-    reference_id: orm.Mapped[uuid.UUID] = orm.mapped_column(default=uuid.uuid4)
+    reference_id: orm.Mapped[uuid.UUID] = orm.mapped_column(default=uuid.uuid4, unique=True, index=True)
 
     @classmethod
     def _scrub_empty(cls, data: dict) -> dict:

--- a/src/recordlinker/routes/patient_router.py
+++ b/src/recordlinker/routes/patient_router.py
@@ -1,0 +1,65 @@
+"""
+recordlinker.routes.patient_router
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This module implements the patient router for the RecordLinker API. Exposing
+the patient API endpoints.
+"""
+import uuid
+
+import fastapi
+import sqlalchemy.orm as orm
+
+from recordlinker import schemas
+from recordlinker.database import get_session
+from recordlinker.linking import mpi_service as service
+
+router = fastapi.APIRouter()
+
+
+@router.post(
+    "/{patient_ref_id}/person",
+    summary="Assign Patient to new Person",
+    status_code=fastapi.status.HTTP_201_CREATED,
+)
+def create_person(
+    patient_ref_id: uuid.UUID, session: orm.Session = fastapi.Depends(get_session)
+) -> schemas.PatientPersonRef:
+    """
+    Create a new Person in the MPI database and link the Patient to them.
+    """
+    patient = service.get_patient_by_reference_id(session, patient_ref_id)
+    if patient is None:
+        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
+
+    person = service.update_person_cluster(session, patient, commit=False)
+    return schemas.PatientPersonRef(
+        patient_ref_id=patient.reference_id, person_ref_id=person.reference_id
+    )
+
+
+@router.patch(
+    "/{patient_ref_id}/person",
+    summary="Assign Patient to existing Person",
+    status_code=fastapi.status.HTTP_200_OK,
+)
+def update_person(
+    patient_ref_id: uuid.UUID,
+    data: schemas.PersonRef,
+    session: orm.Session = fastapi.Depends(get_session),
+) -> schemas.PatientPersonRef:
+    """
+    Update the Person linked on the Patient.
+    """
+    patient = service.get_patient_by_reference_id(session, patient_ref_id)
+    if patient is None:
+        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
+
+    person = service.get_person_by_reference_id(session, data.person_ref_id)
+    if person is None:
+        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_400_BAD_REQUEST)
+
+    person = service.update_person_cluster(session, patient, person, commit=False)
+    return schemas.PatientPersonRef(
+        patient_ref_id=patient.reference_id, person_ref_id=person.reference_id
+    )

--- a/src/recordlinker/routes/patient_router.py
+++ b/src/recordlinker/routes/patient_router.py
@@ -5,6 +5,7 @@ recordlinker.routes.patient_router
 This module implements the patient router for the RecordLinker API. Exposing
 the patient API endpoints.
 """
+
 import uuid
 
 import fastapi
@@ -18,48 +19,48 @@ router = fastapi.APIRouter()
 
 
 @router.post(
-    "/{patient_ref_id}/person",
+    "/{patient_reference_id}/person",
     summary="Assign Patient to new Person",
     status_code=fastapi.status.HTTP_201_CREATED,
 )
 def create_person(
-    patient_ref_id: uuid.UUID, session: orm.Session = fastapi.Depends(get_session)
+    patient_reference_id: uuid.UUID, session: orm.Session = fastapi.Depends(get_session)
 ) -> schemas.PatientPersonRef:
     """
     Create a new Person in the MPI database and link the Patient to them.
     """
-    patient = service.get_patient_by_reference_id(session, patient_ref_id)
+    patient = service.get_patient_by_reference_id(session, patient_reference_id)
     if patient is None:
         raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
 
     person = service.update_person_cluster(session, patient, commit=False)
     return schemas.PatientPersonRef(
-        patient_ref_id=patient.reference_id, person_ref_id=person.reference_id
+        patient_reference_id=patient.reference_id, person_reference_id=person.reference_id
     )
 
 
 @router.patch(
-    "/{patient_ref_id}/person",
+    "/{patient_reference_id}/person",
     summary="Assign Patient to existing Person",
     status_code=fastapi.status.HTTP_200_OK,
 )
 def update_person(
-    patient_ref_id: uuid.UUID,
+    patient_reference_id: uuid.UUID,
     data: schemas.PersonRef,
     session: orm.Session = fastapi.Depends(get_session),
 ) -> schemas.PatientPersonRef:
     """
     Update the Person linked on the Patient.
     """
-    patient = service.get_patient_by_reference_id(session, patient_ref_id)
+    patient = service.get_patient_by_reference_id(session, patient_reference_id)
     if patient is None:
         raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
 
-    person = service.get_person_by_reference_id(session, data.person_ref_id)
+    person = service.get_person_by_reference_id(session, data.person_reference_id)
     if person is None:
         raise fastapi.HTTPException(status_code=fastapi.status.HTTP_400_BAD_REQUEST)
 
     person = service.update_person_cluster(session, patient, person, commit=False)
     return schemas.PatientPersonRef(
-        patient_ref_id=patient.reference_id, person_ref_id=person.reference_id
+        patient_reference_id=patient.reference_id, person_reference_id=person.reference_id
     )

--- a/src/recordlinker/schemas/__init__.py
+++ b/src/recordlinker/schemas/__init__.py
@@ -1,6 +1,8 @@
 from .algorithm import Algorithm
 from .algorithm import AlgorithmPass
 from .algorithm import AlgorithmSummary
+from .mpi import PatientPersonRef
+from .mpi import PersonRef
 from .pii import Feature
 from .pii import PIIRecord
 
@@ -10,4 +12,6 @@ __all__ = [
     "AlgorithmSummary",
     "Feature",
     "PIIRecord",
+    "PersonRef",
+    "PatientPersonRef",
 ]

--- a/src/recordlinker/schemas/mpi.py
+++ b/src/recordlinker/schemas/mpi.py
@@ -1,0 +1,12 @@
+import uuid
+
+import pydantic
+
+
+class PersonRef(pydantic.BaseModel):
+    person_ref_id: uuid.UUID
+
+
+class PatientPersonRef(pydantic.BaseModel):
+    patient_ref_id: uuid.UUID
+    person_ref_id: uuid.UUID

--- a/src/recordlinker/schemas/mpi.py
+++ b/src/recordlinker/schemas/mpi.py
@@ -4,9 +4,9 @@ import pydantic
 
 
 class PersonRef(pydantic.BaseModel):
-    person_ref_id: uuid.UUID
+    person_reference_id: uuid.UUID
 
 
 class PatientPersonRef(pydantic.BaseModel):
-    patient_ref_id: uuid.UUID
-    person_ref_id: uuid.UUID
+    patient_reference_id: uuid.UUID
+    person_reference_id: uuid.UUID

--- a/tests/unit/linking/test_mpi_service.py
+++ b/tests/unit/linking/test_mpi_service.py
@@ -5,7 +5,10 @@ unit.linking.test_mpi_service.py
 This module contains the unit tests for the recordlinker.linking.mpi_service module.
 """
 
+import uuid
+
 import pytest
+import sqlalchemy.exc
 
 from recordlinker import models
 from recordlinker import schemas
@@ -26,7 +29,18 @@ class TestInsertBlockingKeys:
         assert mpi_service.insert_blocking_keys(session, new_patient) == []
 
     def test_patient_with_blocking_keys(self, session, new_patient):
-        new_patient.data = {"name": [{"given": ["Johnathon", "Bill",], "family": "Smith"}], "birthdate": "1980-01-01"}
+        new_patient.data = {
+            "name": [
+                {
+                    "given": [
+                        "Johnathon",
+                        "Bill",
+                    ],
+                    "family": "Smith",
+                }
+            ],
+            "birthdate": "1980-01-01",
+        }
         keys = mpi_service.insert_blocking_keys(session, new_patient)
         assert len(keys) == 4
         for key in keys:
@@ -43,12 +57,31 @@ class TestInsertBlockingKeys:
 
 class TestInsertPatient:
     def test_no_person(self, session):
-        data = {"name": [{"given": ["Johnathon", "Bill",], "family": "Smith"}], "birthdate": "01/01/1980"}
+        data = {
+            "name": [
+                {
+                    "given": [
+                        "Johnathon",
+                        "Bill",
+                    ],
+                    "family": "Smith",
+                }
+            ],
+            "birthdate": "01/01/1980",
+        }
         record = schemas.PIIRecord(**data)
         patient = mpi_service.insert_patient(session, record)
         assert patient.person_id is not None
         assert patient.data["birth_date"] == "1980-01-01"
-        assert patient.data["name"] == [{"given": ["Johnathon", "Bill",], "family": "Smith"}]
+        assert patient.data["name"] == [
+            {
+                "given": [
+                    "Johnathon",
+                    "Bill",
+                ],
+                "family": "Smith",
+            }
+        ]
         assert patient.external_person_id is None
         assert patient.external_person_source is None
         assert patient.person.reference_id is not None
@@ -56,12 +89,29 @@ class TestInsertPatient:
         assert len(patient.blocking_values) == 4
 
     def test_no_person_with_external_id(self, session):
-        data = {"name": [{"given": ["Johnathon",], "family": "Smith"}], "birthdate": "01/01/1980"}
+        data = {
+            "name": [
+                {
+                    "given": [
+                        "Johnathon",
+                    ],
+                    "family": "Smith",
+                }
+            ],
+            "birthdate": "01/01/1980",
+        }
         record = schemas.PIIRecord(**data)
         patient = mpi_service.insert_patient(session, record, external_person_id="123456")
         assert patient.person_id is not None
         assert patient.data["birth_date"] == "1980-01-01"
-        assert patient.data["name"] == [{"given": ["Johnathon",], "family": "Smith"}]
+        assert patient.data["name"] == [
+            {
+                "given": [
+                    "Johnathon",
+                ],
+                "family": "Smith",
+            }
+        ]
         assert patient.external_person_id == "123456"
         assert patient.external_person_source == "IRIS"
         assert patient.person.reference_id is not None
@@ -73,12 +123,29 @@ class TestInsertPatient:
         person = models.Person()
         session.add(person)
         session.flush()
-        data = {"name": [{"given": ["George",], "family": "Harrison"}], "birthdate": "1943-2-25"}
+        data = {
+            "name": [
+                {
+                    "given": [
+                        "George",
+                    ],
+                    "family": "Harrison",
+                }
+            ],
+            "birthdate": "1943-2-25",
+        }
         record = schemas.PIIRecord(**data)
         patient = mpi_service.insert_patient(session, record, person=person)
         assert patient.person_id == person.id
         assert patient.data["birth_date"] == "1943-02-25"
-        assert patient.data["name"] == [{"given": ["George",], "family": "Harrison"}]
+        assert patient.data["name"] == [
+            {
+                "given": [
+                    "George",
+                ],
+                "family": "Harrison",
+            }
+        ]
         assert patient.external_person_id is None
         assert patient.external_person_source is None
         assert len(patient.blocking_values) == 3
@@ -87,9 +154,20 @@ class TestInsertPatient:
         person = models.Person()
         session.add(person)
         session.flush()
-        data = {"name": [{"given": ["George",], "family": "Harrison"}]}
+        data = {
+            "name": [
+                {
+                    "given": [
+                        "George",
+                    ],
+                    "family": "Harrison",
+                }
+            ]
+        }
         record = schemas.PIIRecord(**data)
-        patient = mpi_service.insert_patient(session, record, person=person, external_patient_id="abc")
+        patient = mpi_service.insert_patient(
+            session, record, person=person, external_patient_id="abc"
+        )
         assert patient.person_id == person.id
         assert patient.data == data
         assert patient.external_patient_id == "abc"
@@ -102,74 +180,267 @@ class TestGetBlockData:
     @pytest.fixture
     def prime_index(self, session):
         data = [
-            {"name": [{"given": ["Johnathon", "Bill",], "family": "Smith"}], "birthdate": "01/01/1980"},
-            {"name": [{"given": ["George",], "family": "Harrison"}], "birthdate": "1943-2-25"},
-            {"name": [{"given": ["John",], "family": "Doe"}, {"given": ["John"], "family": "Lewis"}], "birthdate": "1980-01-01"},
-            {"name": [{"given": ["Bill",], "family": "Smith"}], "birthdate": "1980-01-01"},
-            {"name": [{"given": ["John",], "family": "Smith"}], "birthdate": "1980-01-01"},
-            {"name": [{"given": ["John",], "family": "Smith"}], "birthdate": "1985-11-12"},
-            {"name": [{"given": ["Ferris",], "family": "Bueller"}], "birthdate": ""},
+            {
+                "name": [
+                    {
+                        "given": [
+                            "Johnathon",
+                            "Bill",
+                        ],
+                        "family": "Smith",
+                    }
+                ],
+                "birthdate": "01/01/1980",
+            },
+            {
+                "name": [
+                    {
+                        "given": [
+                            "George",
+                        ],
+                        "family": "Harrison",
+                    }
+                ],
+                "birthdate": "1943-2-25",
+            },
+            {
+                "name": [
+                    {
+                        "given": [
+                            "John",
+                        ],
+                        "family": "Doe",
+                    },
+                    {"given": ["John"], "family": "Lewis"},
+                ],
+                "birthdate": "1980-01-01",
+            },
+            {
+                "name": [
+                    {
+                        "given": [
+                            "Bill",
+                        ],
+                        "family": "Smith",
+                    }
+                ],
+                "birthdate": "1980-01-01",
+            },
+            {
+                "name": [
+                    {
+                        "given": [
+                            "John",
+                        ],
+                        "family": "Smith",
+                    }
+                ],
+                "birthdate": "1980-01-01",
+            },
+            {
+                "name": [
+                    {
+                        "given": [
+                            "John",
+                        ],
+                        "family": "Smith",
+                    }
+                ],
+                "birthdate": "1985-11-12",
+            },
+            {
+                "name": [
+                    {
+                        "given": [
+                            "Ferris",
+                        ],
+                        "family": "Bueller",
+                    }
+                ],
+                "birthdate": "",
+            },
         ]
         for datum in data:
             mpi_service.insert_patient(session, schemas.PIIRecord(**datum))
 
     def test_block_invalid_key(self, session):
-        data = {"name": [{"given": ["Johnathon", "Bill",], "family": "Smith"}]}
-        #passing in a invalid id of -1 for a blocking key which should raise a value error
+        data = {
+            "name": [
+                {
+                    "given": [
+                        "Johnathon",
+                        "Bill",
+                    ],
+                    "family": "Smith",
+                }
+            ]
+        }
+        # passing in a invalid id of -1 for a blocking key which should raise a value error
         algorithm_pass = models.AlgorithmPass(blocking_keys=["INVALID"])
         with pytest.raises(ValueError):
             mpi_service.get_block_data(session, schemas.PIIRecord(**data), algorithm_pass)
 
     def test_block_missing_data(self, session, prime_index):
-        data = {"name": [{"given": ["Johnathon", "Bill",], "family": "Smith"}]}
+        data = {
+            "name": [
+                {
+                    "given": [
+                        "Johnathon",
+                        "Bill",
+                    ],
+                    "family": "Smith",
+                }
+            ]
+        }
         algorithm_pass = models.AlgorithmPass(blocking_keys=["BIRTHDATE"])
         matches = mpi_service.get_block_data(session, schemas.PIIRecord(**data), algorithm_pass)
         assert len(matches) == 0
 
     def test_block_empty_block_key(self, session, prime_index):
-        data = {"name": [{"given": ["Ferris",], "family": "Bueller"}], "birthdate": ""}
+        data = {
+            "name": [
+                {
+                    "given": [
+                        "Ferris",
+                    ],
+                    "family": "Bueller",
+                }
+            ],
+            "birthdate": "",
+        }
         algorithm_pass = models.AlgorithmPass(blocking_keys=["BIRTHDATE", "FIRST_NAME"])
         matches = mpi_service.get_block_data(session, schemas.PIIRecord(**data), algorithm_pass)
         assert len(matches) == 0
 
     def test_block_on_birthdate(self, session, prime_index):
-        data = {"name": [{"given": ["Johnathon", "Bill",], "family": "Smith"}], "birthdate": "01/01/1980"}
+        data = {
+            "name": [
+                {
+                    "given": [
+                        "Johnathon",
+                        "Bill",
+                    ],
+                    "family": "Smith",
+                }
+            ],
+            "birthdate": "01/01/1980",
+        }
         algorithm_pass = models.AlgorithmPass(blocking_keys=["BIRTHDATE"])
 
         matches = mpi_service.get_block_data(session, schemas.PIIRecord(**data), algorithm_pass)
         assert len(matches) == 4
-        data = {"name": [{"given": ["Johnathon", "Bill",], "family": "Smith"}], "birthdate": "11/12/1985"}
+        data = {
+            "name": [
+                {
+                    "given": [
+                        "Johnathon",
+                        "Bill",
+                    ],
+                    "family": "Smith",
+                }
+            ],
+            "birthdate": "11/12/1985",
+        }
         matches = mpi_service.get_block_data(session, schemas.PIIRecord(**data), algorithm_pass)
         assert len(matches) == 1
 
     def test_block_on_first_name(self, session, prime_index):
-        data = {"name": [{"given": ["Johnathon", "Bill",], "family": "Smith"}], "birthdate": "01/01/1980"}
+        data = {
+            "name": [
+                {
+                    "given": [
+                        "Johnathon",
+                        "Bill",
+                    ],
+                    "family": "Smith",
+                }
+            ],
+            "birthdate": "01/01/1980",
+        }
         algorithm_pass = models.AlgorithmPass(blocking_keys=["FIRST_NAME"])
         matches = mpi_service.get_block_data(session, schemas.PIIRecord(**data), algorithm_pass)
         assert len(matches) == 5
 
     def test_block_on_birthdate_and_first_name(self, session, prime_index):
-        data = {"name": [{"given": ["Johnathon", "Bill",], "family": "Smith"}], "birthdate": "01/01/1980"}
+        data = {
+            "name": [
+                {
+                    "given": [
+                        "Johnathon",
+                        "Bill",
+                    ],
+                    "family": "Smith",
+                }
+            ],
+            "birthdate": "01/01/1980",
+        }
         algorithm_pass = models.AlgorithmPass(blocking_keys=["BIRTHDATE", "FIRST_NAME"])
         matches = mpi_service.get_block_data(session, schemas.PIIRecord(**data), algorithm_pass)
         assert len(matches) == 4
 
     def test_block_on_birthdate_first_name_and_last_name(self, session, prime_index):
-        data = {"name": [{"given": ["Johnathon", "Bill",], "family": "Smith"}], "birthdate": "01/01/1980"}
-        algorithm_pass = models.AlgorithmPass(blocking_keys=["BIRTHDATE", "FIRST_NAME", "LAST_NAME"])
+        data = {
+            "name": [
+                {
+                    "given": [
+                        "Johnathon",
+                        "Bill",
+                    ],
+                    "family": "Smith",
+                }
+            ],
+            "birthdate": "01/01/1980",
+        }
+        algorithm_pass = models.AlgorithmPass(
+            blocking_keys=["BIRTHDATE", "FIRST_NAME", "LAST_NAME"]
+        )
         matches = mpi_service.get_block_data(session, schemas.PIIRecord(**data), algorithm_pass)
         assert len(matches) == 3
-        data = {"name": [{"given": ["Billy",], "family": "Smitty"}], "birthdate": "Jan 1 1980"}
+        data = {
+            "name": [
+                {
+                    "given": [
+                        "Billy",
+                    ],
+                    "family": "Smitty",
+                }
+            ],
+            "birthdate": "Jan 1 1980",
+        }
         matches = mpi_service.get_block_data(session, schemas.PIIRecord(**data), algorithm_pass)
         assert len(matches) == 2
-        data = {"name": [{"given": ["Johnathon", "Bill",], "family": "Doeherty"}], "birthdate": "Jan 1 1980"}
+        data = {
+            "name": [
+                {
+                    "given": [
+                        "Johnathon",
+                        "Bill",
+                    ],
+                    "family": "Doeherty",
+                }
+            ],
+            "birthdate": "Jan 1 1980",
+        }
         matches = mpi_service.get_block_data(session, schemas.PIIRecord(**data), algorithm_pass)
         assert len(matches) == 0
 
     def test_block_on_multiple_names(self, session, prime_index):
-        data = {"name": [{"use": "official", "given": ["John", "Doe"], "family": "Smith"}, {"use": "maiden", "given": ["John"], "family": "Doe"}]}
+        data = {
+            "name": [
+                {"use": "official", "given": ["John", "Doe"], "family": "Smith"},
+                {"use": "maiden", "given": ["John"], "family": "Doe"},
+            ]
+        }
         algorithm_pass = models.AlgorithmPass(blocking_keys=["FIRST_NAME", "LAST_NAME"])
-        algorithm_pass = models.AlgorithmPass(id=1, algorithm_id=1, blocking_keys=["FIRST_NAME","LAST_NAME"], evaluators={}, rule="", cluster_ratio=1.0, kwargs={})
+        algorithm_pass = models.AlgorithmPass(
+            id=1,
+            algorithm_id=1,
+            blocking_keys=["FIRST_NAME", "LAST_NAME"],
+            evaluators={},
+            rule="",
+            cluster_ratio=1.0,
+            kwargs={},
+        )
         matches = mpi_service.get_block_data(session, schemas.PIIRecord(**data), algorithm_pass)
         assert len(matches) == 4
 
@@ -180,11 +451,97 @@ class TestGetBlockData:
         assert len(matches) == 0
 
     def test_block_on_duplicates(self, session):
-        data = {"external_id": "d3ecb447-d05f-4ec1-8ef1-ce4bbda59a25", "birth_date": "1997-12-09", "sex": "F", "mrn": "7bb85f23-044b-1f92-3521-f2cf258601b0", "address": [{"line": ["783 Cronin Stravenue"], "city": "Los Angeles", "state": "CA", "postal_code": "90405", "country": "US", "latitude": 34.12688209447149, "longitude": -118.56442326530481, "extension": [{"url": "http://hl7.org/fhir/StructureDefinition/geolocation", "extension": [{"url": "latitude", "valueDecimal": 34.12688209447149}, {"url": "longitude", "valueDecimal": -118.56442326530481}]}]}], "name": [{"family": "Rodr\u00edguez701", "given": ["Lourdes258", "Blanca837"], "use": "official", "prefix": ["Ms."]}], "phone": [{"system": "phone", "value": "555-401-5073", "use": "home"}]}
+        data = {
+            "external_id": "d3ecb447-d05f-4ec1-8ef1-ce4bbda59a25",
+            "birth_date": "1997-12-09",
+            "sex": "F",
+            "mrn": "7bb85f23-044b-1f92-3521-f2cf258601b0",
+            "address": [
+                {
+                    "line": ["783 Cronin Stravenue"],
+                    "city": "Los Angeles",
+                    "state": "CA",
+                    "postal_code": "90405",
+                    "country": "US",
+                    "latitude": 34.12688209447149,
+                    "longitude": -118.56442326530481,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/geolocation",
+                            "extension": [
+                                {"url": "latitude", "valueDecimal": 34.12688209447149},
+                                {"url": "longitude", "valueDecimal": -118.56442326530481},
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "name": [
+                {
+                    "family": "Rodr\u00edguez701",
+                    "given": ["Lourdes258", "Blanca837"],
+                    "use": "official",
+                    "prefix": ["Ms."],
+                }
+            ],
+            "phone": [{"system": "phone", "value": "555-401-5073", "use": "home"}],
+        }
         mpi_service.insert_patient(session, schemas.PIIRecord(**data))
         mpi_service.insert_patient(session, schemas.PIIRecord(**data))
         mpi_service.insert_patient(session, schemas.PIIRecord(**data))
-        algorithm_pass = models.AlgorithmPass(blocking_keys=["FIRST_NAME", "LAST_NAME", "ZIP", "SEX"])
+        algorithm_pass = models.AlgorithmPass(
+            blocking_keys=["FIRST_NAME", "LAST_NAME", "ZIP", "SEX"]
+        )
 
         matches = mpi_service.get_block_data(session, schemas.PIIRecord(**data), algorithm_pass)
         assert len(matches) == 3
+
+
+class TestGetPatientByReferenceId:
+    def test_invalid_reference_id(self, session):
+        with pytest.raises(sqlalchemy.exc.SQLAlchemyError):
+            mpi_service.get_patient_by_reference_id(session, "123")
+
+    def test_no_reference_id(self, session):
+        assert mpi_service.get_patient_by_reference_id(session, uuid.uuid4()) is None
+
+    def test_reference_id(self, session):
+        patient = models.Patient(person=models.Person(), data={})
+        session.add(patient)
+        session.flush()
+        assert mpi_service.get_patient_by_reference_id(session, patient.reference_id) == patient
+
+
+class TestGetPersonByReferenceId:
+    def test_invalid_reference_id(self, session):
+        with pytest.raises(sqlalchemy.exc.SQLAlchemyError):
+            mpi_service.get_person_by_reference_id(session, "123")
+
+    def test_no_reference_id(self, session):
+        assert mpi_service.get_person_by_reference_id(session, uuid.uuid4()) is None
+
+    def test_reference_id(self, session):
+        person = models.Person()
+        session.add(person)
+        session.flush()
+        assert mpi_service.get_person_by_reference_id(session, person.reference_id) == person
+
+
+class TestUpdatePersonCluster:
+    def test_no_person(self, session):
+        person = models.Person()
+        patient = models.Patient(person=person, data={})
+        session.add(patient)
+        session.flush()
+        original_person_id = patient.person.id
+        person = mpi_service.update_person_cluster(session, patient)
+        assert person.id != original_person_id
+
+    def test_with_person(self, session):
+        patient = models.Patient(person=models.Person(), data={})
+        session.add(patient)
+        new_person = models.Person()
+        session.add(new_person)
+        session.flush()
+        person = mpi_service.update_person_cluster(session, patient, person=new_person)
+        assert person.id == new_person.id

--- a/tests/unit/routes/test_patient_router.py
+++ b/tests/unit/routes/test_patient_router.py
@@ -1,0 +1,67 @@
+"""
+unit.routes.test_patient_router.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This module contains the unit tests for the recordlinker.routes.patient_router module.
+"""
+
+import uuid
+
+from recordlinker import models
+
+
+class TestCreatePerson:
+    def test_invalid_reference_id(self, client):
+        response = client.post("/patient/123/person")
+        assert response.status_code == 422
+
+    def test_invalid_patient(self, client):
+        response = client.post(f"/patient/{uuid.uuid4()}/person")
+        assert response.status_code == 404
+
+    def test_create_person(self, client):
+        original_person = models.Person()
+        patient = models.Patient(person=original_person, data={})
+        client.session.add(patient)
+        client.session.flush()
+
+        resp = client.post(f"/patient/{patient.reference_id}/person")
+        assert resp.status_code == 201
+        assert resp.json()["patient_reference_id"] == str(patient.reference_id)
+        assert resp.json()["person_reference_id"] != str(original_person.reference_id)
+
+
+class TestUpdatePerson:
+    def test_invalid_reference_id(self, client):
+        response = client.patch("/patient/123/person")
+        assert response.status_code == 422
+
+    def test_invalid_patient(self, client):
+        data = {"person_reference_id": str(uuid.uuid4())}
+        response = client.patch(f"/patient/{uuid.uuid4()}/person", json=data)
+        assert response.status_code == 404
+
+    def test_invalid_person(self, client):
+        patient = models.Patient(person=models.Person(), data={})
+        client.session.add(patient)
+        client.session.flush()
+
+        data = {"person_reference_id": str(uuid.uuid4())}
+        response = client.patch(f"/patient/{patient.reference_id}/person", json=data)
+        assert response.status_code == 400
+
+    def test_update_person(self, client):
+        original_person = models.Person()
+        patient = models.Patient(person=original_person, data={})
+        client.session.add(patient)
+        client.session.flush()
+
+        new_person = models.Person()
+        client.session.add(new_person)
+        client.session.flush()
+
+        data = {"person_reference_id": str(new_person.reference_id)}
+        resp = client.patch(f"/patient/{patient.reference_id}/person", json=data)
+        assert resp.status_code == 200
+        assert resp.json()["patient_reference_id"] == str(patient.reference_id)
+        assert resp.json()["person_reference_id"] == str(new_person.reference_id)


### PR DESCRIPTION
## Description
Adding two new endpoints to support updating the Person cluster a Patient belongs to.  One is for assigning the Patient to a specific cluster, and another is for assigning them to a new cluster.

## Related Issues
closes #96 

## Additional Notes
- `POST /patient/<ref-id>/person` takes an empty payload, creates a new Person cluster, assigns the Patient to that cluster and returns back reference ids for both the Patient and Person.
- `PATCH /patient/<ref-id>/person` takes a person ref id payload, assigned the Patient to that existing Person and returns back reference ids for both the Patient and Person.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
