### PR TITLE
Ability to delete a Patient record

### DIFF
--- a/src/recordlinker/database/mpi_service.py
+++ b/src/recordlinker/database/mpi_service.py
@@ -236,3 +236,15 @@ def reset_mpi(session: orm.Session, commit: bool = True):
     session.query(models.Person).delete()
     if commit:
         session.commit()
+
+def delete_patient(session: orm.Session, obj: models.Patient, commit: bool = False) -> None:
+    """
+    Deletes an Patient from the database
+
+    :param session: The database session
+    :param obj: The Patient to delete
+    :param commit: Commit the transaction
+    """
+    session.delete(obj)
+    if commit:
+        session.commit()

--- a/src/recordlinker/routes/patient_router.py
+++ b/src/recordlinker/routes/patient_router.py
@@ -64,3 +64,21 @@ def update_person(
     return schemas.PatientPersonRef(
         patient_reference_id=patient.reference_id, person_reference_id=person.reference_id
     )
+
+@router.delete(
+    "/{patient_reference_id}",
+    summary="Delete a Patient",
+    status_code=fastapi.status.HTTP_204_NO_CONTENT,
+)
+def delete_patient(
+    patient_reference_id: uuid.UUID, session: orm.Session = fastapi.Depends(get_session)
+) -> None:
+    """
+    Delete a Patient from the mpi database.
+    """
+    patient = service.get_patient_by_reference_id(session, patient_reference_id)
+
+    if patient is None:
+        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
+    
+    return service.delete_patient(session, patient)

--- a/tests/unit/routes/test_patient_router.py
+++ b/tests/unit/routes/test_patient_router.py
@@ -65,3 +65,21 @@ class TestUpdatePerson:
         assert resp.status_code == 200
         assert resp.json()["patient_reference_id"] == str(patient.reference_id)
         assert resp.json()["person_reference_id"] == str(new_person.reference_id)
+
+class TestDeletePatient:
+    def test_invalid_reference_id(self, client):
+        response = client.delete(f"/patient/{uuid.uuid4()}")
+        assert response.status_code == 404
+
+    def test_delete_patient(self, client):
+        patient = models.Patient()
+        client.session.add(patient)
+        client.session.flush()
+
+        resp = client.delete(f"/patient/{patient.reference_id}")
+        assert resp.status_code == 204
+
+        patient = (
+            client.session.query(models.Patient).filter(models.Patient.reference_id == patient.reference_id).first()
+        )
+        assert patient is None


### PR DESCRIPTION
## Description
Mistakes can happen, and there could be times when customers send a record to the link API by mistake (could be a known duplicate document, or just an error in the workflow). We should have the ability to "undo" those mistakes. Create a new DELETE /patient/<patient_reference_id> endpoint that will allow users to remove a known patient record.

## Related Issues
closes #138 

## Additional Notes


<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
