### PR TITLE
adding Features and Blocking Keys for phone and email

### DIFF
--- a/docs/site/reference.md
+++ b/docs/site/reference.md
@@ -13,7 +13,7 @@ linkage evaluation phase. The following features are supported:
 
 `BIRTHDATE`
 
-:   The patient's birthdate in the format `YYYY-MM-DD`.
+:   The patient's birthdate (normalized to `YYYY-MM-DD`).
 
 `MRN`
 
@@ -25,7 +25,7 @@ linkage evaluation phase. The following features are supported:
 
 `SEX`
 
-:   The patient's sex in the format of `M`, `F`, or `U` for unknown.
+:   The patient's sex (normalized to `M`, `F`, or `U` for unknown).
 
 `GENDER`
 
@@ -75,6 +75,14 @@ linkage evaluation phase. The following features are supported:
 
 :   The patient's phone, email, fax, or other contact information.
 
+`PHONE`
+
+:   The patient's phone number (normalized to 10 digits).
+
+`EMAIL`
+
+:   The patient's email address.
+
 `DRIVERS_LICENSE`
 
 :   The patient's driver's license number.
@@ -112,6 +120,14 @@ patient data and used during query retrieval. The following blocking key types a
 `ADDRESS` (ID: **7**)
 
 :   The first 4 characters of the patient's address.
+
+`PHONE` (ID: **8**)
+
+:   The last 4 digits of the patient's phone number.
+
+`EMAIL` (ID: **9**)
+
+:   The first 4 characters of the patient's email address.
 
 
 ### Evaluation Functions

--- a/src/recordlinker/models/mpi.py
+++ b/src/recordlinker/models/mpi.py
@@ -127,6 +127,8 @@ class BlockingKey(enum.Enum):
     FIRST_NAME = ("FIRST_NAME", 5, "First 4 characters of the first name")
     LAST_NAME = ("LAST_NAME", 6, "First 4 characters of the last name")
     ADDRESS = ("ADDRESS", 7, "First 4 characters of the address")
+    PHONE = ("PHONE", 8, "Last 4 characters of the phone number")
+    EMAIL = ("EMAIL", 9, "First 4 characters of the email address")
 
     def __init__(self, value: str, _id: int, description: str):
         self._value = value

--- a/tests/unit/routes/test_seed_router.py
+++ b/tests/unit/routes/test_seed_router.py
@@ -38,7 +38,7 @@ class TestBatch:
         assert sum(len(p["patients"]) for p in persons) == 1285
         assert client.session.query(models.Person).count() == 100
         assert client.session.query(models.Patient).count() == 1285
-        assert client.session.query(models.BlockingValue).count() == 8995
+        assert client.session.query(models.BlockingValue).count() == 10280
 
     @mock.patch("recordlinker.database.algorithm_service.default_algorithm")
     def test_seed_and_link(self, mock_algorithm, basic_algorithm, client):


### PR DESCRIPTION
## Description
Add features and blocking keys for the telecom phone number and email values

## Related Issues
closes #147 

## Additional Notes
The work in #26 suggested also making SSN a blocking key, however since the ongoing work on id triplets (#133) will redo the implementation of SSN and also make it a blocking key per RFC-001, this work has been intentionally left out of this PR.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
