### PR TITLE
Fix: pin pythonjsonlogger to 2.X.X

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "sqlalchemy",
     "rapidfuzz",
     # Observability
-    "python-json-logger",
+    "python-json-logger>=2.0.0,<3.0.0",
     "asgi-correlation-id",
     # Database drivers
     "psycopg2-binary",  # PostgreSQL


### PR DESCRIPTION
## Description
Version 3.1.0 of this library has renamed some modules that are causing import errors

## Additional Notes
https://github.com/nhairs/python-json-logger/releases/tag/v3.1.0

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
