### PR TITLE
Fix: adding DB_URI var when building docs in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install '.[dev]'
+          export DB_URI="sqlite:///:memory:"
           export INITIAL_ALGORITHMS=""
           export VERSION=${{ env.NEXT_TAG }}
           ./scripts/build_docs.sh _site


### PR DESCRIPTION
## Description
The .env no longer exists in the repo, so we must manually set a value for the required DB_URI

## Additional Notes
Example build failure https://github.com/CDCgov/RecordLinker/actions/runs/12319787147/job/34387640857

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
