### PR TITLE
Patient Details Endpoints

### DIFF
--- a/src/recordlinker/database/mpi_service.py
+++ b/src/recordlinker/database/mpi_service.py
@@ -160,7 +160,7 @@ def update_patient(
     commit: bool = True,
 ) -> models.Patient:
     """
-    Insert a new patient record into the database.
+    Updates an existing patient record in the database.
 
     :param session: The database session
     :param patient: The Patient to update

--- a/src/recordlinker/routes/patient_router.py
+++ b/src/recordlinker/routes/patient_router.py
@@ -84,7 +84,13 @@ def create_patient(
     if person is None:
         raise fastapi.HTTPException(
             status_code=fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Person not found. Must include a person_reference_id that already exists in the MPI.",
+            detail=[
+                {
+                    "loc": ["body", "person_reference_id"],
+                    "msg": "Person not found",
+                    "type": "value_error",
+                }
+            ],
         )
 
     patient = service.insert_patient(
@@ -122,7 +128,13 @@ def update_patient(
         if person is None:
             raise fastapi.HTTPException(
                 status_code=fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail="Person not found. Must include a person_reference_id that already exists in the MPI.",
+                detail=[
+                    {
+                        "loc": ["body", "person_reference_id"],
+                        "msg": "Person not found",
+                        "type": "value_error",
+                    }
+                ],
             )
 
     external_patient_id = getattr(payload.record, "external_id", None)

--- a/src/recordlinker/routes/patient_router.py
+++ b/src/recordlinker/routes/patient_router.py
@@ -83,8 +83,6 @@ def delete_patient(
     
     return service.delete_patient(session, patient)
 
-
-# TODO: Could add the person reference id to the payload instead of the path
 @router.post(
     "/person/{person_reference_id}",
     summary="Create a patient record and link to an existing person",

--- a/src/recordlinker/routes/patient_router.py
+++ b/src/recordlinker/routes/patient_router.py
@@ -77,7 +77,7 @@ def create_patient(
     session: orm.Session = fastapi.Depends(get_session),
 ) -> schemas.PatientRef:
     """
-    Create a new patient record in the MPI
+    Create a new patient record in the MPI and link to an existing person.
     """
     person = service.get_person_by_reference_id(session, payload.person_reference_id)
 

--- a/src/recordlinker/routes/patient_router.py
+++ b/src/recordlinker/routes/patient_router.py
@@ -82,7 +82,10 @@ def create_patient(
     person = service.get_person_by_reference_id(session, payload.person_reference_id)
 
     if person is None:
-        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Person not found. Must include a person_reference_id that already exists in the MPI.")
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Person not found. Must include a person_reference_id that already exists in the MPI.",
+        )
 
     patient = service.insert_patient(
         session,
@@ -117,7 +120,10 @@ def update_patient(
     if payload.person_reference_id:
         person = service.get_person_by_reference_id(session, payload.person_reference_id)
         if person is None:
-            raise fastapi.HTTPException(status_code=fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY)
+            raise fastapi.HTTPException(
+                status_code=fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Person not found. Must include a person_reference_id that already exists in the MPI.",
+            )
 
     external_patient_id = getattr(payload.record, "external_id", None)
     patient = service.update_patient(

--- a/src/recordlinker/routes/patient_router.py
+++ b/src/recordlinker/routes/patient_router.py
@@ -82,7 +82,7 @@ def create_patient(
     person = service.get_person_by_reference_id(session, payload.person_reference_id)
 
     if person is None:
-        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY)
+        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Person not found. Must include a person_reference_id that already exists in the MPI.")
 
     patient = service.insert_patient(
         session,

--- a/src/recordlinker/routes/patient_router.py
+++ b/src/recordlinker/routes/patient_router.py
@@ -85,7 +85,11 @@ def create_patient(
         raise fastapi.HTTPException(status_code=fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY)
 
     patient = service.insert_patient(
-        session, payload.record, person=person, external_patient_id=payload.record.external_id
+        session,
+        payload.record,
+        person=person,
+        external_patient_id=payload.record.external_id,
+        commit=False,
     )
     return schemas.PatientRef(
         patient_reference_id=patient.reference_id, external_patient_id=patient.external_patient_id
@@ -122,6 +126,7 @@ def update_patient(
         person=person,
         record=payload.record,
         external_patient_id=external_patient_id,
+        commit=False,
     )
     return schemas.PatientRef(
         patient_reference_id=patient.reference_id, external_patient_id=patient.external_patient_id

--- a/src/recordlinker/routes/patient_router.py
+++ b/src/recordlinker/routes/patient_router.py
@@ -82,3 +82,45 @@ def delete_patient(
         raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
     
     return service.delete_patient(session, patient)
+
+
+# TODO: Could add the person reference id to the payload instead of the path
+@router.post(
+    "/person/{person_reference_id}",
+    summary="Create a patient record and link to an existing person",
+    status_code=fastapi.status.HTTP_201_CREATED,
+)
+def create_patient(
+    person_reference_id: uuid.UUID, record: schemas.PIIRecord, session: orm.Session = fastapi.Depends(get_session)
+) -> schemas.PatientRef:
+    """
+    Create a new patient record in the mpi
+    """
+    person = service.get_person_by_reference_id(session, person_reference_id)
+
+    if person is None:
+        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
+    
+    print("made it here")
+    patient = service.insert_patient(session, record, person)
+    return schemas.PatientRef(reference_id=patient.reference_id)
+
+
+@router.patch(
+    "/{patient_reference_id}",
+    summary="Update a patient record",
+    status_code=fastapi.status.HTTP_200_OK,
+)
+def update_patient(
+    patient_reference_id: uuid.UUID, record: schemas.PIIRecord, session: orm.Session = fastapi.Depends(get_session)
+) -> schemas.PatientRef:
+    """
+    Update an existing patient record in the mpi
+    """
+    patient = service.get_patient_by_reference_id(session, patient_reference_id)
+    if patient is None:
+        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
+    
+    #update the patient record with the new data
+
+    #return a reference object to the updated patient

--- a/src/recordlinker/schemas/__init__.py
+++ b/src/recordlinker/schemas/__init__.py
@@ -9,8 +9,10 @@ from .link import LinkResult
 from .link import MatchFhirResponse
 from .link import MatchResponse
 from .link import Prediction
+from .mpi import PatientCreatePayload
 from .mpi import PatientPersonRef
 from .mpi import PatientRef
+from .mpi import PatientUpdatePayload
 from .mpi import PersonRef
 from .pii import Feature
 from .pii import FeatureAttribute
@@ -38,6 +40,8 @@ __all__ = [
     "PersonRef",
     "PatientRef",
     "PatientPersonRef",
+    "PatientCreatePayload",
+    "PatientUpdatePayload",
     "Cluster",
     "ClusterGroup",
     "PersonCluster",

--- a/src/recordlinker/schemas/mpi.py
+++ b/src/recordlinker/schemas/mpi.py
@@ -35,6 +35,6 @@ class PatientUpdatePayload(pydantic.BaseModel):
         """
         Ensure that either person_reference_id or record is not None.
         """
-        if self.person_reference_id is None and not self.record:
+        if self.person_reference_id is None and self.record is None:
             raise ValueError("at least one of person_reference_id or record must be provided")
         return self

--- a/src/recordlinker/schemas/mpi.py
+++ b/src/recordlinker/schemas/mpi.py
@@ -1,6 +1,9 @@
+import typing
 import uuid
 
 import pydantic
+
+from .pii import PIIRecord
 
 
 class PersonRef(pydantic.BaseModel):
@@ -16,3 +19,22 @@ class PatientRef(pydantic.BaseModel):
 class PatientPersonRef(pydantic.BaseModel):
     patient_reference_id: uuid.UUID
     person_reference_id: uuid.UUID
+
+
+class PatientCreatePayload(pydantic.BaseModel):
+    person_reference_id: uuid.UUID
+    record: PIIRecord
+
+
+class PatientUpdatePayload(pydantic.BaseModel):
+    person_reference_id: uuid.UUID | None = None
+    record: PIIRecord | None = None
+
+    @pydantic.model_validator(mode="after")
+    def validate_both_not_empty(self) -> typing.Self:
+        """
+        Ensure that either person_reference_id or record is not None.
+        """
+        if self.person_reference_id is None and not self.record:
+            raise ValueError("at least one of person_reference_id or record must be provided")
+        return self

--- a/tests/unit/database/test_mpi_service.py
+++ b/tests/unit/database/test_mpi_service.py
@@ -310,6 +310,65 @@ class TestBulkInsertPatientsMySQL:
             assert mpi_service.bulk_insert_patients(session, [])
 
 
+class TestUpdatePatient:
+    def test_no_patient(self, session):
+        with pytest.raises(ValueError):
+            mpi_service.update_patient(session, models.Patient(), schemas.PIIRecord())
+
+    def test_update_record(self, session):
+        patient = models.Patient(person=models.Person(), data={"sex": "M"})
+        session.add(patient)
+        session.flush()
+        session.add(models.BlockingValue(patient_id=patient.id, blockingkey=models.BlockingKey.SEX.id, value="M"))
+        record = schemas.PIIRecord(**{"name": [{"given": ["John"], "family": "Doe"}], "birthdate": "1980-01-01"})
+        patient = mpi_service.update_patient(session, patient, record=record)
+        assert patient.data == {"name": [{"given": ["John"], "family": "Doe"}], "birth_date": "1980-01-01"}
+        assert len(patient.blocking_values) == 3
+
+    def test_update_person(self, session):
+        person = models.Person()
+        session.add(person)
+        patient = models.Patient()
+        session.add(patient)
+        session.flush()
+        patient = mpi_service.update_patient(session, patient, person=person)
+        assert patient.person_id == person.id
+
+    def test_update_external_patient_id(self, session):
+        patient = models.Patient()
+        session.add(patient)
+        session.flush()
+
+        patient = mpi_service.update_patient(session, patient, external_patient_id="123")
+        assert patient.external_patient_id == "123"
+
+
+class TestDeleteBlockingValuesForPatient:
+    def test_no_values(self, session):
+        other_patient = models.Patient()
+        session.add(other_patient)
+        session.flush()
+        session.add(models.BlockingValue(patient_id=other_patient.id, blockingkey=models.BlockingKey.FIRST_NAME.id, value="John"))
+        session.flush()
+        patient = models.Patient()
+        session.add(patient)
+        session.flush()
+        assert len(patient.blocking_values) == 0
+        mpi_service.delete_blocking_values_for_patient(session, patient)
+        assert len(patient.blocking_values) == 0
+
+    def test_with_values(self, session):
+        patient = models.Patient()
+        session.add(patient)
+        session.flush()
+        session.add(models.BlockingValue(patient_id=patient.id, blockingkey=models.BlockingKey.FIRST_NAME.id, value="John"))
+        session.add(models.BlockingValue(patient_id=patient.id, blockingkey=models.BlockingKey.LAST_NAME.id, value="Smith"))
+        session.flush()
+        assert len(patient.blocking_values) == 2
+        mpi_service.delete_blocking_values_for_patient(session, patient)
+        assert len(patient.blocking_values) == 0
+
+
 class TestGetBlockData:
     @pytest.fixture
     def prime_index(self, session):

--- a/tests/unit/routes/test_patient_router.py
+++ b/tests/unit/routes/test_patient_router.py
@@ -6,10 +6,8 @@ This module contains the unit tests for the recordlinker.routes.patient_router m
 """
 
 import uuid
-import json
 
 from recordlinker import models
-from recordlinker import schemas
 
 
 class TestCreatePerson:
@@ -69,6 +67,74 @@ class TestUpdatePerson:
         assert resp.json()["patient_reference_id"] == str(patient.reference_id)
         assert resp.json()["person_reference_id"] == str(new_person.reference_id)
 
+
+class TestCreatePatient:
+    def test_missing_data(self, client):
+        response = client.post("/patient")
+        assert response.status_code == 422
+
+    def test_invalid_person(self, client):
+        data = {"person_reference_id": str(uuid.uuid4())}, {"record": {}}
+        response = client.post("/patient", json=data)
+        assert response.status_code == 422
+
+    def test_create_patient(self, client):
+        person = models.Person()
+        client.session.add(person)
+        client.session.flush()
+
+        data = {
+            "person_reference_id": str(person.reference_id),
+            "record": {"name": [{"given": ["John"], "family": "Doe"}], "external_id": "123"},
+        }
+        response = client.post("/patient", json=data)
+        assert response.status_code == 201
+        patient = client.session.query(models.Patient).first()
+        assert response.json() == {"patient_reference_id": str(patient.reference_id), "external_patient_id": "123"}
+        assert len(patient.blocking_values) == 2
+        assert patient.person == person
+        assert patient.data == data["record"]
+
+
+class TestUpdatePatient:
+    def test_missing_data(self, client):
+        response = client.patch(f"/patient/{uuid.uuid4()}")
+        assert response.status_code == 422
+
+    def test_invalid_reference_id(self, client):
+        data = {"person_reference_id": str(uuid.uuid4())}
+        response = client.patch(f"/patient/{uuid.uuid4()}", json=data)
+        assert response.status_code == 404
+
+    def test_invalid_person(self, client):
+        patient = models.Patient()
+        client.session.add(patient)
+        client.session.flush()
+
+        data = {"person_reference_id": str(uuid.uuid4())}
+        response = client.patch(f"/patient/{patient.reference_id}", json=data)
+        assert response.status_code == 422
+
+    def test_update_patient(self, client):
+        person = models.Person()
+        client.session.add(person)
+        patient = models.Patient()
+        client.session.add(patient)
+        client.session.flush()
+
+        data = {
+            "person_reference_id": str(person.reference_id),
+            "record": {"name": [{"given": ["John"], "family": "Doe"}], "external_id": "123"},
+        }
+        response = client.patch(f"/patient/{patient.reference_id}", json=data)
+        assert response.status_code == 200
+        assert response.json() == {"patient_reference_id": str(patient.reference_id), "external_patient_id": "123"}
+        patient = client.session.query(models.Patient).get(patient.id)
+        assert len(patient.blocking_values) == 2
+        assert patient.person == person
+        assert patient.data == data["record"]
+
+
 class TestDeletePatient:
     def test_invalid_reference_id(self, client):
         response = client.delete(f"/patient/{uuid.uuid4()}")
@@ -83,11 +149,8 @@ class TestDeletePatient:
         assert resp.status_code == 204
 
         patient = (
-            client.session.query(models.Patient).filter(models.Patient.reference_id == patient.reference_id).first()
+            client.session.query(models.Patient)
+            .filter(models.Patient.reference_id == patient.reference_id)
+            .first()
         )
         assert patient is None
-
-class TestCreatePatient:
-    def test_invalid_person(self, client):
-        response = client.post(f"/patient/person/{uuid.uuid4()}", json={})
-        assert response.status_code == 404

--- a/tests/unit/routes/test_patient_router.py
+++ b/tests/unit/routes/test_patient_router.py
@@ -12,93 +12,82 @@ from recordlinker import models
 from recordlinker import schemas
 
 
-# class TestCreatePerson:
-#     def test_invalid_reference_id(self, client):
-#         print("testing")
-#         response = client.post("/patient/123/person")
-#         assert response.status_code == 422
+class TestCreatePerson:
+    def test_invalid_reference_id(self, client):
+        print("testing")
+        response = client.post("/patient/123/person")
+        assert response.status_code == 422
 
-#     def test_invalid_patient(self, client):
-#         response = client.post(f"/patient/{uuid.uuid4()}/person")
-#         assert response.status_code == 404
+    def test_invalid_patient(self, client):
+        response = client.post(f"/patient/{uuid.uuid4()}/person")
+        assert response.status_code == 404
 
-#     def test_create_person(self, client):
-#         original_person = models.Person()
-#         patient = models.Patient(person=original_person, data={})
-#         client.session.add(patient)
-#         client.session.flush()
+    def test_create_person(self, client):
+        original_person = models.Person()
+        patient = models.Patient(person=original_person, data={})
+        client.session.add(patient)
+        client.session.flush()
 
-#         resp = client.post(f"/patient/{patient.reference_id}/person")
-#         assert resp.status_code == 201
-#         assert resp.json()["patient_reference_id"] == str(patient.reference_id)
-#         assert resp.json()["person_reference_id"] != str(original_person.reference_id)
+        resp = client.post(f"/patient/{patient.reference_id}/person")
+        assert resp.status_code == 201
+        assert resp.json()["patient_reference_id"] == str(patient.reference_id)
+        assert resp.json()["person_reference_id"] != str(original_person.reference_id)
 
 
-# class TestUpdatePerson:
-#     def test_invalid_reference_id(self, client):
-#         response = client.patch("/patient/123/person")
-#         assert response.status_code == 422
+class TestUpdatePerson:
+    def test_invalid_reference_id(self, client):
+        response = client.patch("/patient/123/person")
+        assert response.status_code == 422
 
-#     def test_invalid_patient(self, client):
-#         data = {"person_reference_id": str(uuid.uuid4())}
-#         response = client.patch(f"/patient/{uuid.uuid4()}/person", json=data)
-#         assert response.status_code == 404
+    def test_invalid_patient(self, client):
+        data = {"person_reference_id": str(uuid.uuid4())}
+        response = client.patch(f"/patient/{uuid.uuid4()}/person", json=data)
+        assert response.status_code == 404
 
-#     def test_invalid_person(self, client):
-#         patient = models.Patient(person=models.Person(), data={})
-#         client.session.add(patient)
-#         client.session.flush()
+    def test_invalid_person(self, client):
+        patient = models.Patient(person=models.Person(), data={})
+        client.session.add(patient)
+        client.session.flush()
 
-#         data = {"person_reference_id": str(uuid.uuid4())}
-#         response = client.patch(f"/patient/{patient.reference_id}/person", json=data)
-#         assert response.status_code == 422
+        data = {"person_reference_id": str(uuid.uuid4())}
+        response = client.patch(f"/patient/{patient.reference_id}/person", json=data)
+        assert response.status_code == 422
 
-#     def test_update_person(self, client):
-#         original_person = models.Person()
-#         patient = models.Patient(person=original_person, data={})
-#         client.session.add(patient)
-#         client.session.flush()
+    def test_update_person(self, client):
+        original_person = models.Person()
+        patient = models.Patient(person=original_person, data={})
+        client.session.add(patient)
+        client.session.flush()
 
-#         new_person = models.Person()
-#         client.session.add(new_person)
-#         client.session.flush()
+        new_person = models.Person()
+        client.session.add(new_person)
+        client.session.flush()
 
-#         data = {"person_reference_id": str(new_person.reference_id)}
-#         resp = client.patch(f"/patient/{patient.reference_id}/person", json=data)
-#         assert resp.status_code == 200
-#         assert resp.json()["patient_reference_id"] == str(patient.reference_id)
-#         assert resp.json()["person_reference_id"] == str(new_person.reference_id)
+        data = {"person_reference_id": str(new_person.reference_id)}
+        resp = client.patch(f"/patient/{patient.reference_id}/person", json=data)
+        assert resp.status_code == 200
+        assert resp.json()["patient_reference_id"] == str(patient.reference_id)
+        assert resp.json()["person_reference_id"] == str(new_person.reference_id)
 
-# class TestDeletePatient:
-#     def test_invalid_reference_id(self, client):
-#         response = client.delete(f"/patient/{uuid.uuid4()}")
-#         assert response.status_code == 404
+class TestDeletePatient:
+    def test_invalid_reference_id(self, client):
+        response = client.delete(f"/patient/{uuid.uuid4()}")
+        assert response.status_code == 404
 
-#     def test_delete_patient(self, client):
-#         patient = models.Patient()
-#         client.session.add(patient)
-#         client.session.flush()
+    def test_delete_patient(self, client):
+        patient = models.Patient()
+        client.session.add(patient)
+        client.session.flush()
 
-#         resp = client.delete(f"/patient/{patient.reference_id}")
-#         assert resp.status_code == 204
+        resp = client.delete(f"/patient/{patient.reference_id}")
+        assert resp.status_code == 204
 
-#         patient = (
-#             client.session.query(models.Patient).filter(models.Patient.reference_id == patient.reference_id).first()
-#         )
-#         assert patient is None
+        patient = (
+            client.session.query(models.Patient).filter(models.Patient.reference_id == patient.reference_id).first()
+        )
+        assert patient is None
 
 class TestCreatePatient:
     def test_invalid_person(self, client):
         response = client.post(f"/patient/person/{uuid.uuid4()}", json={})
         assert response.status_code == 404
-
-    # def test_create_patient(self, client):
-    #     person = models.Person()
-    #     client.session.add(person)
-    #     client.session.flush()
-
-    #     resp = client.post(f"/patient/person/{person.reference_id}", json={})
-    #     assert resp.status_code == 201
-
-    #     assert resp.json()["person_reference_id"] == str(person.reference_id)
-    #     assert resp.json()["patient_reference_id"] is not None

--- a/tests/unit/routes/test_patient_router.py
+++ b/tests/unit/routes/test_patient_router.py
@@ -6,80 +6,99 @@ This module contains the unit tests for the recordlinker.routes.patient_router m
 """
 
 import uuid
+import json
 
 from recordlinker import models
+from recordlinker import schemas
 
 
-class TestCreatePerson:
-    def test_invalid_reference_id(self, client):
-        response = client.post("/patient/123/person")
-        assert response.status_code == 422
+# class TestCreatePerson:
+#     def test_invalid_reference_id(self, client):
+#         print("testing")
+#         response = client.post("/patient/123/person")
+#         assert response.status_code == 422
 
-    def test_invalid_patient(self, client):
-        response = client.post(f"/patient/{uuid.uuid4()}/person")
-        assert response.status_code == 404
+#     def test_invalid_patient(self, client):
+#         response = client.post(f"/patient/{uuid.uuid4()}/person")
+#         assert response.status_code == 404
 
-    def test_create_person(self, client):
-        original_person = models.Person()
-        patient = models.Patient(person=original_person, data={})
-        client.session.add(patient)
-        client.session.flush()
+#     def test_create_person(self, client):
+#         original_person = models.Person()
+#         patient = models.Patient(person=original_person, data={})
+#         client.session.add(patient)
+#         client.session.flush()
 
-        resp = client.post(f"/patient/{patient.reference_id}/person")
-        assert resp.status_code == 201
-        assert resp.json()["patient_reference_id"] == str(patient.reference_id)
-        assert resp.json()["person_reference_id"] != str(original_person.reference_id)
+#         resp = client.post(f"/patient/{patient.reference_id}/person")
+#         assert resp.status_code == 201
+#         assert resp.json()["patient_reference_id"] == str(patient.reference_id)
+#         assert resp.json()["person_reference_id"] != str(original_person.reference_id)
 
 
-class TestUpdatePerson:
-    def test_invalid_reference_id(self, client):
-        response = client.patch("/patient/123/person")
-        assert response.status_code == 422
+# class TestUpdatePerson:
+#     def test_invalid_reference_id(self, client):
+#         response = client.patch("/patient/123/person")
+#         assert response.status_code == 422
 
-    def test_invalid_patient(self, client):
-        data = {"person_reference_id": str(uuid.uuid4())}
-        response = client.patch(f"/patient/{uuid.uuid4()}/person", json=data)
-        assert response.status_code == 404
+#     def test_invalid_patient(self, client):
+#         data = {"person_reference_id": str(uuid.uuid4())}
+#         response = client.patch(f"/patient/{uuid.uuid4()}/person", json=data)
+#         assert response.status_code == 404
 
+#     def test_invalid_person(self, client):
+#         patient = models.Patient(person=models.Person(), data={})
+#         client.session.add(patient)
+#         client.session.flush()
+
+#         data = {"person_reference_id": str(uuid.uuid4())}
+#         response = client.patch(f"/patient/{patient.reference_id}/person", json=data)
+#         assert response.status_code == 422
+
+#     def test_update_person(self, client):
+#         original_person = models.Person()
+#         patient = models.Patient(person=original_person, data={})
+#         client.session.add(patient)
+#         client.session.flush()
+
+#         new_person = models.Person()
+#         client.session.add(new_person)
+#         client.session.flush()
+
+#         data = {"person_reference_id": str(new_person.reference_id)}
+#         resp = client.patch(f"/patient/{patient.reference_id}/person", json=data)
+#         assert resp.status_code == 200
+#         assert resp.json()["patient_reference_id"] == str(patient.reference_id)
+#         assert resp.json()["person_reference_id"] == str(new_person.reference_id)
+
+# class TestDeletePatient:
+#     def test_invalid_reference_id(self, client):
+#         response = client.delete(f"/patient/{uuid.uuid4()}")
+#         assert response.status_code == 404
+
+#     def test_delete_patient(self, client):
+#         patient = models.Patient()
+#         client.session.add(patient)
+#         client.session.flush()
+
+#         resp = client.delete(f"/patient/{patient.reference_id}")
+#         assert resp.status_code == 204
+
+#         patient = (
+#             client.session.query(models.Patient).filter(models.Patient.reference_id == patient.reference_id).first()
+#         )
+#         assert patient is None
+
+class TestCreatePatient:
     def test_invalid_person(self, client):
-        patient = models.Patient(person=models.Person(), data={})
-        client.session.add(patient)
-        client.session.flush()
-
-        data = {"person_reference_id": str(uuid.uuid4())}
-        response = client.patch(f"/patient/{patient.reference_id}/person", json=data)
-        assert response.status_code == 422
-
-    def test_update_person(self, client):
-        original_person = models.Person()
-        patient = models.Patient(person=original_person, data={})
-        client.session.add(patient)
-        client.session.flush()
-
-        new_person = models.Person()
-        client.session.add(new_person)
-        client.session.flush()
-
-        data = {"person_reference_id": str(new_person.reference_id)}
-        resp = client.patch(f"/patient/{patient.reference_id}/person", json=data)
-        assert resp.status_code == 200
-        assert resp.json()["patient_reference_id"] == str(patient.reference_id)
-        assert resp.json()["person_reference_id"] == str(new_person.reference_id)
-
-class TestDeletePatient:
-    def test_invalid_reference_id(self, client):
-        response = client.delete(f"/patient/{uuid.uuid4()}")
+        response = client.post(f"/patient/person/{uuid.uuid4()}", json={})
         assert response.status_code == 404
 
-    def test_delete_patient(self, client):
-        patient = models.Patient()
-        client.session.add(patient)
-        client.session.flush()
+    # def test_create_patient(self, client):
+    #     person = models.Person()
+    #     client.session.add(person)
+    #     client.session.flush()
 
-        resp = client.delete(f"/patient/{patient.reference_id}")
-        assert resp.status_code == 204
+    #     resp = client.post(f"/patient/person/{person.reference_id}", json={})
+    #     assert resp.status_code == 201
 
-        patient = (
-            client.session.query(models.Patient).filter(models.Patient.reference_id == patient.reference_id).first()
-        )
-        assert patient is None
+    #     assert resp.json()["person_reference_id"] == str(person.reference_id)
+    #     assert resp.json()["patient_reference_id"] is not None

--- a/tests/unit/routes/test_patient_router.py
+++ b/tests/unit/routes/test_patient_router.py
@@ -74,7 +74,7 @@ class TestCreatePatient:
         assert response.status_code == 422
 
     def test_invalid_person(self, client):
-        data = {"person_reference_id": str(uuid.uuid4())}, {"record": {}}
+        data = {"person_reference_id": str(uuid.uuid4()), "record": {}}
         response = client.post("/patient", json=data)
         assert response.status_code == 422
 
@@ -115,6 +115,14 @@ class TestUpdatePatient:
         response = client.patch(f"/patient/{patient.reference_id}", json=data)
         assert response.status_code == 422
 
+    def test_no_data_to_update(self, client):
+        patient = models.Patient()
+        client.session.add(patient)
+        client.session.flush()
+
+        response = client.patch(f"/patient/{patient.reference_id}", json={})
+        assert response.status_code == 422
+
     def test_update_patient(self, client):
         person = models.Person()
         client.session.add(person)
@@ -129,7 +137,7 @@ class TestUpdatePatient:
         response = client.patch(f"/patient/{patient.reference_id}", json=data)
         assert response.status_code == 200
         assert response.json() == {"patient_reference_id": str(patient.reference_id), "external_patient_id": "123"}
-        patient = client.session.query(models.Patient).get(patient.id)
+        patient = client.session.get(models.Patient, patient.id)
         assert len(patient.blocking_values) == 2
         assert patient.person == person
         assert patient.data == data["record"]

--- a/tests/unit/routes/test_patient_router.py
+++ b/tests/unit/routes/test_patient_router.py
@@ -76,6 +76,15 @@ class TestCreatePatient:
         data = {"person_reference_id": str(uuid.uuid4()), "record": {}}
         response = client.post("/patient", json=data)
         assert response.status_code == 422
+        assert response.json() == {
+            "detail": [
+                {
+                    "loc": ["body", "person_reference_id"],
+                    "msg": "Person not found",
+                    "type": "value_error",
+                }
+            ]
+        }
 
     def test_create_patient(self, client):
         person = models.Person()
@@ -89,7 +98,10 @@ class TestCreatePatient:
         response = client.post("/patient", json=data)
         assert response.status_code == 201
         patient = client.session.query(models.Patient).first()
-        assert response.json() == {"patient_reference_id": str(patient.reference_id), "external_patient_id": "123"}
+        assert response.json() == {
+            "patient_reference_id": str(patient.reference_id),
+            "external_patient_id": "123",
+        }
         assert len(patient.blocking_values) == 2
         assert patient.person == person
         assert patient.data == data["record"]
@@ -113,6 +125,15 @@ class TestUpdatePatient:
         data = {"person_reference_id": str(uuid.uuid4())}
         response = client.patch(f"/patient/{patient.reference_id}", json=data)
         assert response.status_code == 422
+        assert response.json() == {
+            "detail": [
+                {
+                    "loc": ["body", "person_reference_id"],
+                    "msg": "Person not found",
+                    "type": "value_error",
+                }
+            ]
+        }
 
     def test_no_data_to_update(self, client):
         patient = models.Patient()
@@ -135,7 +156,10 @@ class TestUpdatePatient:
         }
         response = client.patch(f"/patient/{patient.reference_id}", json=data)
         assert response.status_code == 200
-        assert response.json() == {"patient_reference_id": str(patient.reference_id), "external_patient_id": "123"}
+        assert response.json() == {
+            "patient_reference_id": str(patient.reference_id),
+            "external_patient_id": "123",
+        }
         patient = client.session.get(models.Patient, patient.id)
         assert len(patient.blocking_values) == 2
         assert patient.person == person

--- a/tests/unit/routes/test_patient_router.py
+++ b/tests/unit/routes/test_patient_router.py
@@ -12,7 +12,6 @@ from recordlinker import models
 
 class TestCreatePerson:
     def test_invalid_reference_id(self, client):
-        print("testing")
         response = client.post("/patient/123/person")
         assert response.status_code == 422
 


### PR DESCRIPTION
## Description
Add two new API endpoints that allow users to directly add/update patient record details in the MPI.

## Related Issues
closes #159 

## Additional Notes
`POST /patient -d '{"record": "...", "person": "person_reference_id"}'`
Add the above endpoint to allow users to directly add a patient record to the MPI, skipping the record linkage algorithm.

`PATCH /patient/<patient-reference-id> -d '{"record": "...", "person": "person_reference_id"}'`
Add the above endpoint to allow users to update an existing patient record in the MPI.
NOTE: For this operation, the `record` and `person` attributes are optional.  If not specified, the existing value will stay unchanged.  However, at least 1 must be specified.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
