### PR TITLE
fix: docker builds with libodbc

### DIFF
--- a/.github/workflows/check_smoke_tests.yml
+++ b/.github/workflows/check_smoke_tests.yml
@@ -10,14 +10,32 @@ jobs:
   smoke_tests:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        database: [postgres, sqlite, mysql, sqlserver]  # Matrix for database types
+
     services:
-      db:
+      postgres:
         image: postgres:17
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: pw
         ports:
           - 5432:5432
+        env:
+          POSTGRES_PASSWORD: pw
+
+      mysql:
+        image: mysql:8
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ROOT_PASSWORD: pw
+
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        ports:
+          - 1433:1433
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: "YourStrong!Passw0rd"
 
     steps:
     - name: Check out repository
@@ -32,11 +50,20 @@ jobs:
 
     - name: Start RecordLinker Service and Run Smoke Tests
       run: |
+        if [[ "${{ matrix.database }}" == "postgres" ]]; then
+          export DB_URI="postgresql+psycopg2://postgres:pw@localhost:5432/postgres"
+        elif [[ "${{ matrix.database }}" == "sqlite" ]]; then
+          export DB_URI="sqlite:///testdb.sqlite3"
+        elif [[ "${{ matrix.database }}" == "mysql" ]]; then
+          export DB_URI="mysql+pymysql://root:pw@localhost:3306/mysql"
+        elif [[ "${{ matrix.database }}" == "sqlserver" ]]; then
+          export DB_URI="mssql+pyodbc://sa:YourStrong!Passw0rd@localhost:1433/master?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=yes"
+        fi
+
         # Start Record Linker Service
         docker run -d --name rl-service \
           --network="host" \
-          -e DB_URI="postgresql+psycopg2://postgres:pw@localhost:5432/postgres" \
-          -p 8080:8080 \
+          -e DB_URI=$DB_URI \
           rl-service-image
 
         # Wait for the RL Service to be healthy

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN pip install --upgrade pip
 # Conditionally install ODBC driver for SQL Server.
 # There is no ODBC driver for linux/arm64 architecture, so SQL Server support
 # is limited to linux/amd64 architecture
-RUN if [ "$USE_MSSQL" = "true" && "$(dpkg --print-architecture)" = "amd64" ]; then \
+RUN if [ "$USE_MSSQL" = "true" ] && [ "$(dpkg --print-architecture)" = "amd64" ]; then \
         apt-get install -y gnupg2 apt-transport-https && \
         curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/microsoft.gpg && \
         curl https://packages.microsoft.com/config/debian/11/prod.list | tee /etc/apt/sources.list.d/mssql-release.list && \


### PR DESCRIPTION
## Description
Corrects the syntax of the if block in the Dockerfile to ensure proper evaluation for installing msodbcsql18 and unixodbc-dev. This fix resolves an issue where the Record Linker image fails to start when configured with a sqlserver DB_URI.

## Additional Notes
This is a significant issue for users who want to: a) use our published Docker images on ghcr.io and b) connect to a sqlserver database. The if block on line 30 of the Dockerfile has syntax that works with /bin/bash but not with /bin/sh. As a result, the step was always skipped during the image build process.

This update introduces a database matrix to our smoke tests, enabling the Docker image to be tested against all four supported databases, not just PostgreSQL.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [x] The code follows best practices and conventions.
- [x] The changes implement the desired functionality or fix the reported issue.
- [x] The tests cover the new changes and pass successfully.
- [x] Any potential edge cases or error scenarios have been considered.
