### PR TITLE
Add BlockingKey descriptions to openapi.json

### DIFF
--- a/docs/site/reference.md
+++ b/docs/site/reference.md
@@ -77,7 +77,7 @@ linkage evaluation phase. The following features are supported:
 
 `IDENTIFIER:<type>`
 
-:   The patient's specific identifier type. For example, `IDENTIFIER:MR` would be the patient's medical record number.  Unlike `IDENTIFIER`, this will ONLY compare values of a specific type.  Valid type codes can be found here http://hl7.org/fhir/R4/v2/0203/index.html.
+:   The patient's specific identifier type. For example, `IDENTIFIER:MR` would be the patient's medical record number.  Unlike `IDENTIFIER`, this will ONLY compare values of a specific type.  Valid type codes can be found on [the FHIR v2 Identifier Type page](http://hl7.org/fhir/R4/v2/0203/index.html).
 
 
 ### Blocking Key Types

--- a/docs/site/reference.md
+++ b/docs/site/reference.md
@@ -77,7 +77,7 @@ linkage evaluation phase. The following features are supported:
 
 `IDENTIFIER:<type>`
 
-:   The patient's specific identifier type. For example, `IDENTIFIER:MR` would be the patient's medical record number.  Unlike `IDENTIFIER`, this will ONLY compare values of a specific type.  Valid type codes can be found on [the FHIR v2 Identifier Type page](http://hl7.org/fhir/R4/v2/0203/index.html).
+:   The patient's specific identifier type. For example, `IDENTIFIER:MR` would be the patient's medical record number.  Unlike `IDENTIFIER`, this will ONLY compare values of a specific type.  Valid type codes can be found on [the R4 FHIR Identifier Type v2 page](http://hl7.org/fhir/R4/v2/0203/index.html).
 
 
 ### Blocking Key Types

--- a/docs/site/reference.md
+++ b/docs/site/reference.md
@@ -119,7 +119,7 @@ patient data and used during query retrieval. The following blocking key types a
 
 `IDENTIFIER` (ID: **10**)
 
-:  The identifier triplet containing only the type, authority, and last 4 digits of the value
+:  A colon separated string of the identifier type, first 2 characters of the authority and last 4 characters of the value.
 
 
 ### Evaluation Functions

--- a/src/recordlinker/models/mpi.py
+++ b/src/recordlinker/models/mpi.py
@@ -40,7 +40,9 @@ class Patient(Base):
     __tablename__ = "mpi_patient"
 
     id: orm.Mapped[int] = orm.mapped_column(get_bigint_pk(), autoincrement=True, primary_key=True)
-    person_id: orm.Mapped[int] = orm.mapped_column(schema.ForeignKey(f"{Person.__tablename__}.id"), nullable=True)
+    person_id: orm.Mapped[int] = orm.mapped_column(
+        schema.ForeignKey(f"{Person.__tablename__}.id"), nullable=True
+    )
     person: orm.Mapped["Person"] = orm.relationship(back_populates="patients")
     # NOTE: We're using a protected attribute here to store the data string, as we
     # want getter/setter access to the data dictionary to trigger updating the
@@ -121,14 +123,18 @@ class BlockingKey(enum.Enum):
     """
 
     BIRTHDATE = ("BIRTHDATE", 1, "Date of birth as YYYY-MM-DD")
-    SEX = ("SEX", 3, "Sex at birth; M, F or U")
+    SEX = ("SEX", 3, "Sex at birth; M or F")
     ZIP = ("ZIP", 4, "5 digital US Postal Code")
     FIRST_NAME = ("FIRST_NAME", 5, "First 4 characters of the first name")
     LAST_NAME = ("LAST_NAME", 6, "First 4 characters of the last name")
     ADDRESS = ("ADDRESS", 7, "First 4 characters of the address")
     PHONE = ("PHONE", 8, "Last 4 characters of the phone number")
     EMAIL = ("EMAIL", 9, "First 4 characters of the email address")
-    IDENTIFIER = ("IDENTIFIER", 10, "Identifier triplet with only last 4 character of the value. Format \"type:authority:value\"")
+    IDENTIFIER = (
+        "IDENTIFIER",
+        10,
+        "A colon separated string of the identifier type, first 2 characters of the authority and last 4 characters of the value",
+    )
 
     def __init__(self, value: str, _id: int, description: str):
         self._value = value

--- a/src/recordlinker/schemas/algorithm.py
+++ b/src/recordlinker/schemas/algorithm.py
@@ -44,7 +44,12 @@ class AlgorithmPass(pydantic.BaseModel):
 
     model_config = pydantic.ConfigDict(from_attributes=True, use_enum_values=True)
 
-    blocking_keys: list[BlockingKey]
+    blocking_keys: list[BlockingKey] = pydantic.Field(
+        ...,
+        json_schema_extra={
+            "enum": [{"value": k.value, "description": k.description} for k in BlockingKey],
+        },
+    )
     evaluators: list[Evaluator]
     rule: matchers.RuleFunc
     kwargs: dict[str, typing.Any] = {}


### PR DESCRIPTION
## Description
Small updates to the existing BlockingKey descriptions and changing the schema to include the description as well as the value when rendering the information in `GET /openapi.json`

## Related Issues
closes #187 

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
