### PR TITLE
Build msodbc drivers into arm64 images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,12 @@ RUN pip install --upgrade pip
 # Conditionally install ODBC driver for SQL Server.
 # There is no ODBC driver for linux/arm64 architecture, so SQL Server support
 # is limited to linux/amd64 architecture
-RUN if [ "$USE_MSSQL" = "true" ] && [ "$(dpkg --print-architecture)" = "amd64" ]; then \
-        apt-get install -y gnupg2 apt-transport-https && \
-        curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/microsoft.gpg && \
-        curl https://packages.microsoft.com/config/debian/11/prod.list | tee /etc/apt/sources.list.d/mssql-release.list && \
-        apt-get update && \
-        ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev; \
+RUN if [ "$USE_MSSQL" = "true" ]; then \
+    apt-get install -y gnupg2 apt-transport-https && \
+    curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/microsoft.gpg && \
+    curl https://packages.microsoft.com/config/debian/11/prod.list | tee /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get update && \
+    ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev; \
     fi
 
 WORKDIR /code
@@ -46,8 +46,8 @@ RUN pip install "$(printf '%s' ".[${ENVIRONMENT}]")"
 
 # Conditionally install OpenTelemetry packages if USE_OTEL is true
 RUN if [ "$USE_OTEL" = "true" ]; then \
-        pip install opentelemetry-distro opentelemetry-exporter-otlp && \
-        opentelemetry-bootstrap -a install; \
+    pip install opentelemetry-distro opentelemetry-exporter-otlp && \
+    opentelemetry-bootstrap -a install; \
     fi
 
 # Copy over the rest of the code

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,11 @@ RUN pip install --upgrade pip
 
 # Conditionally install ODBC driver for SQL Server.
 RUN if [ "$USE_MSSQL" = "true" ]; then \
-    apt-get install -y gnupg2 apt-transport-https && \
-    curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/microsoft.gpg && \
-    curl https://packages.microsoft.com/config/debian/11/prod.list | tee /etc/apt/sources.list.d/mssql-release.list && \
-    apt-get update && \
-    ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev; \
+        apt-get install -y gnupg2 apt-transport-https && \
+        curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/microsoft.gpg && \
+        curl https://packages.microsoft.com/config/debian/11/prod.list | tee /etc/apt/sources.list.d/mssql-release.list && \
+        apt-get update && \
+        ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev; \
     fi
 
 WORKDIR /code
@@ -44,8 +44,8 @@ RUN pip install "$(printf '%s' ".[${ENVIRONMENT}]")"
 
 # Conditionally install OpenTelemetry packages if USE_OTEL is true
 RUN if [ "$USE_OTEL" = "true" ]; then \
-    pip install opentelemetry-distro opentelemetry-exporter-otlp && \
-    opentelemetry-bootstrap -a install; \
+        pip install opentelemetry-distro opentelemetry-exporter-otlp && \
+        opentelemetry-bootstrap -a install; \
     fi
 
 # Copy over the rest of the code

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install curl -y
 RUN pip install --upgrade pip
 
 # Conditionally install ODBC driver for SQL Server.
-# There is no ODBC driver for linux/arm64 architecture, so SQL Server support
-# is limited to linux/amd64 architecture
 RUN if [ "$USE_MSSQL" = "true" ]; then \
     apt-get install -y gnupg2 apt-transport-https && \
     curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/microsoft.gpg && \


### PR DESCRIPTION
## Description
msodbc18 can now be installed on ARM64 (eg Mac M1) platforms so we can remove the if block in the Dockerfile to exclude this process for those platforms.


## Related Issues
#184 

## Additional Notes
I'm not sure if we have a good way to test the success of this change but if I followed the Teams conversation correctly, we have confirmed that NBS was able to get this working.
