### PR TITLE
new local scheme of dirty-tag for developer installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ namespaces = false
 [tool.setuptools_scm]
 write_to = "src/recordlinker/_version.py"
 version_scheme = "post-release"
-local_scheme = "node-and-timestamp"
+local_scheme = "dirty-tag"
 fallback_version = "0.0.0"
 
 [tool.ruff]


### PR DESCRIPTION
## Description
When we install RecordLinker into an environment, a version number is automatically calculated from git data using setuptools scm. If the HEAD is a version tag, then the version is automatically calculated to be that.  In development environments, though, we take the last version and add a "post.0" to it, showing it's a new release post the last named one.

Additionally, we were previously calculating a timestamp to add to that "post.0" value based on when HEAD was committed.  This worked most of the time, however if the developer has a dirty index, the wheel wouldn't build correctly.  We don't need that, and it's fine if a developer tries to install / reinstall RecordLinker in an environment with a dirty index. So to get around that, we'll stop adding the timestamp to the end of "post.0" and instead just call it "post.0+dirty" (if the index is indeed dirty).

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
