### PR TITLE
Appropriately handle race unknown

### DIFF
--- a/src/recordlinker/schemas/pii.py
+++ b/src/recordlinker/schemas/pii.py
@@ -347,7 +347,7 @@ class PIIRecord(pydantic.BaseModel):
                 if name.family:
                     yield name.family
         elif attribute == FeatureAttribute.RACE:
-            if self.race:
+            if self.race and self.race not in [Race.UNKNOWN, Race.ASKED_UNKNOWN]:
                 yield str(self.race)
         elif attribute == FeatureAttribute.TELECOM:
             for telecom in self.telecom:

--- a/tests/unit/schemas/test_pii.py
+++ b/tests/unit/schemas/test_pii.py
@@ -266,11 +266,11 @@ class TestPIIRecord:
         record = pii.PIIRecord(race="asked but unknown")
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == []
         record = pii.PIIRecord(race="asian")
-        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == [pii.Race.ASIAN]
+        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == ["ASIAN"]
         record = pii.PIIRecord(race="african american")
-        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == [pii.Race.BLACK]
+        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == ["BLACK"]
         record = pii.PIIRecord(race="white")
-        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == [pii.Race.WHITE]
+        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == ["WHITE"]
         
 
     def test_blocking_keys_invalid(self):

--- a/tests/unit/schemas/test_pii.py
+++ b/tests/unit/schemas/test_pii.py
@@ -148,6 +148,8 @@ class TestPIIRecord:
         assert record.race == pii.Race.BLACK
         record = pii.PIIRecord(race="native hawaiian or other pacific islander")
         assert record.race == pii.Race.HAWAIIAN
+        record = pii.PIIRecord(race="asked unknown")
+        assert record.race == pii.Race.ASKED_UNKNOWN
         record = pii.PIIRecord(race="asked but unknown")
         assert record.race == pii.Race.ASKED_UNKNOWN
         record = pii.PIIRecord(race="unknown")
@@ -257,6 +259,18 @@ class TestPIIRecord:
         # IDENTIFIER with suffix
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.IDENTIFIER, suffix="MR"))) == ["MR::123456"]
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.IDENTIFIER, suffix="SS"))) == ["SS::123-45-6789"]
+
+        # Other fields work okay, few more checks on difference race yield values
+        record = pii.PIIRecord(race="asked unknown")
+        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == []
+        record = pii.PIIRecord(race="asked but unknown")
+        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == []
+        record = pii.PIIRecord(race="asian")
+        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == [pii.Race.ASIAN]
+        record = pii.PIIRecord(race="african american")
+        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == [pii.Race.BLACK]
+        record = pii.PIIRecord(race="white")
+        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == [pii.Race.WHITE]
         
 
     def test_blocking_keys_invalid(self):

--- a/tests/unit/schemas/test_pii.py
+++ b/tests/unit/schemas/test_pii.py
@@ -242,7 +242,7 @@ class TestPIIRecord:
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.GIVEN_NAME))) == ["John", "L", "Jane"]
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.FIRST_NAME))) == ["John", "Jane"]
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.LAST_NAME))) == ["Doe", "Smith"]
-        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == ["UNKNOWN"]
+        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) is None
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.TELECOM))) == [
             "555-123-4567",
             "(555) 987-6543",

--- a/tests/unit/schemas/test_pii.py
+++ b/tests/unit/schemas/test_pii.py
@@ -242,7 +242,7 @@ class TestPIIRecord:
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.GIVEN_NAME))) == ["John", "L", "Jane"]
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.FIRST_NAME))) == ["John", "Jane"]
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.LAST_NAME))) == ["Doe", "Smith"]
-        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) is None
+        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == []
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.TELECOM))) == [
             "555-123-4567",
             "(555) 987-6543",


### PR DESCRIPTION
## Description
This PR removes the `feature_iter` yield for the `RACE` field whenever an incoming record has a value for that field of `UNKNOWN` or `ASKED_UNKNOWN`. This ensures that, downstream, we don't perform fuzzy string comparisons against known race values and `UNKNOWN` and thereby award some log odds points where none should be.

## Related Issues
#193 

## Additional Notes
n/a
<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
