### PR TITLE
patient / person API endpoints for retrieving data

### DIFF
--- a/src/recordlinker/database/mpi_service.py
+++ b/src/recordlinker/database/mpi_service.py
@@ -254,9 +254,15 @@ def get_patients_by_reference_ids(
 ) -> list[models.Patient | None]:
     """
     Retrieve all the Patients by their reference ids. If a Patient is not found,
-    a None value will be returned in the list for that reference id.
+    a None value will be returned in the list for that reference id. Eagerly load
+    the Person associated with the Patient.
     """
-    query = select(models.Patient).where(models.Patient.reference_id.in_(reference_ids))
+    query = (
+        select(models.Patient)
+        .where(models.Patient.reference_id.in_(reference_ids))
+        .options(orm.joinedload(models.Patient.person))
+    )
+
     patients_by_id: dict[uuid.UUID, models.Patient] = {
         patient.reference_id: patient for patient in session.execute(query).scalars().all()
     }

--- a/src/recordlinker/routes/patient_router.py
+++ b/src/recordlinker/routes/patient_router.py
@@ -115,6 +115,30 @@ def create_patient(
     )
 
 
+@router.get(
+    "/{patient_reference_id}",
+    summary="Retrieve a patient record",
+    status_code=fastapi.status.HTTP_200_OK,
+)
+def get_patient(
+    patient_reference_id: uuid.UUID,
+    session: orm.Session = fastapi.Depends(get_session),
+) -> schemas.PatientInfo:
+    """
+    Retrieve an existing patient record in the MPI
+    """
+    patient = service.get_patients_by_reference_ids(session, patient_reference_id)[0]
+    if patient is None:
+        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
+
+    return schemas.PatientInfo(
+        patient_reference_id=patient.reference_id,
+        person_reference_id=patient.person.reference_id,
+        record=patient.record,
+        external_patient_id=patient.external_patient_id,
+        external_person_id=patient.external_person_id)
+
+
 @router.patch(
     "/{patient_reference_id}",
     summary="Update a patient record",

--- a/src/recordlinker/routes/person_router.py
+++ b/src/recordlinker/routes/person_router.py
@@ -75,3 +75,25 @@ def update_person(
 
     person = service.update_person_cluster(session, patients, person, commit=False)
     return schemas.PersonRef(person_reference_id=person.reference_id)
+
+
+@router.get(
+    "/{person_reference_id}",
+    summary="Retrieve a person cluster",
+    status_code=fastapi.status.HTTP_200_OK,
+)
+def get_person(
+    person_reference_id: uuid.UUID,
+    session: orm.Session = fastapi.Depends(get_session),
+) -> schemas.PersonInfo:
+    """
+    Retrieve an existing person cluster in the MPI
+    """
+    person = service.get_person_by_reference_id(session, person_reference_id)
+    if person is None:
+        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
+
+    return schemas.PersonInfo(
+        person_reference_id=person.reference_id,
+        patient_reference_ids=[patient.reference_id for patient in person.patients],
+    )

--- a/src/recordlinker/schemas/__init__.py
+++ b/src/recordlinker/schemas/__init__.py
@@ -15,6 +15,7 @@ from .mpi import PatientPersonRef
 from .mpi import PatientRef
 from .mpi import PatientRefs
 from .mpi import PatientUpdatePayload
+from .mpi import PersonInfo
 from .mpi import PersonRef
 from .pii import Feature
 from .pii import FeatureAttribute
@@ -46,6 +47,7 @@ __all__ = [
     "PatientCreatePayload",
     "PatientUpdatePayload",
     "PatientInfo",
+    "PersonInfo",
     "Cluster",
     "ClusterGroup",
     "PersonCluster",

--- a/src/recordlinker/schemas/__init__.py
+++ b/src/recordlinker/schemas/__init__.py
@@ -10,6 +10,7 @@ from .link import MatchFhirResponse
 from .link import MatchResponse
 from .link import Prediction
 from .mpi import PatientCreatePayload
+from .mpi import PatientInfo
 from .mpi import PatientPersonRef
 from .mpi import PatientRef
 from .mpi import PatientRefs
@@ -44,6 +45,7 @@ __all__ = [
     "PatientRefs",
     "PatientCreatePayload",
     "PatientUpdatePayload",
+    "PatientInfo",
     "Cluster",
     "ClusterGroup",
     "PersonCluster",

--- a/src/recordlinker/schemas/mpi.py
+++ b/src/recordlinker/schemas/mpi.py
@@ -42,3 +42,11 @@ class PatientUpdatePayload(pydantic.BaseModel):
         if self.person_reference_id is None and self.record is None:
             raise ValueError("at least one of person_reference_id or record must be provided")
         return self
+
+
+class PatientInfo(pydantic.BaseModel):
+    patient_reference_id: uuid.UUID
+    person_reference_id: uuid.UUID
+    record: PIIRecord
+    external_patient_id: str | None = None
+    external_person_id: str | None = None

--- a/src/recordlinker/schemas/mpi.py
+++ b/src/recordlinker/schemas/mpi.py
@@ -50,3 +50,8 @@ class PatientInfo(pydantic.BaseModel):
     record: PIIRecord
     external_patient_id: str | None = None
     external_person_id: str | None = None
+
+
+class PersonInfo(pydantic.BaseModel):
+    person_reference_id: uuid.UUID
+    patient_reference_ids: list[uuid.UUID]

--- a/tests/unit/database/test_mpi_service.py
+++ b/tests/unit/database/test_mpi_service.py
@@ -9,7 +9,8 @@ import uuid
 
 import pytest
 import sqlalchemy.exc
-from conftest import db_dialect, count_queries
+from conftest import count_queries
+from conftest import db_dialect
 
 from recordlinker import models
 from recordlinker import schemas
@@ -317,10 +318,19 @@ class TestUpdatePatient:
         patient = models.Patient(person=models.Person(), data={"sex": "M"})
         session.add(patient)
         session.flush()
-        session.add(models.BlockingValue(patient_id=patient.id, blockingkey=models.BlockingKey.SEX.id, value="M"))
-        record = schemas.PIIRecord(**{"name": [{"given": ["John"], "family": "Doe"}], "birthdate": "1980-01-01"})
+        session.add(
+            models.BlockingValue(
+                patient_id=patient.id, blockingkey=models.BlockingKey.SEX.id, value="M"
+            )
+        )
+        record = schemas.PIIRecord(
+            **{"name": [{"given": ["John"], "family": "Doe"}], "birthdate": "1980-01-01"}
+        )
         patient = mpi_service.update_patient(session, patient, record=record)
-        assert patient.data == {"name": [{"given": ["John"], "family": "Doe"}], "birth_date": "1980-01-01"}
+        assert patient.data == {
+            "name": [{"given": ["John"], "family": "Doe"}],
+            "birth_date": "1980-01-01",
+        }
         assert len(patient.blocking_values) == 3
 
     def test_update_person(self, session):
@@ -346,7 +356,13 @@ class TestDeleteBlockingValuesForPatient:
         other_patient = models.Patient()
         session.add(other_patient)
         session.flush()
-        session.add(models.BlockingValue(patient_id=other_patient.id, blockingkey=models.BlockingKey.FIRST_NAME.id, value="John"))
+        session.add(
+            models.BlockingValue(
+                patient_id=other_patient.id,
+                blockingkey=models.BlockingKey.FIRST_NAME.id,
+                value="John",
+            )
+        )
         session.flush()
         patient = models.Patient()
         session.add(patient)
@@ -359,8 +375,16 @@ class TestDeleteBlockingValuesForPatient:
         patient = models.Patient()
         session.add(patient)
         session.flush()
-        session.add(models.BlockingValue(patient_id=patient.id, blockingkey=models.BlockingKey.FIRST_NAME.id, value="John"))
-        session.add(models.BlockingValue(patient_id=patient.id, blockingkey=models.BlockingKey.LAST_NAME.id, value="Smith"))
+        session.add(
+            models.BlockingValue(
+                patient_id=patient.id, blockingkey=models.BlockingKey.FIRST_NAME.id, value="John"
+            )
+        )
+        session.add(
+            models.BlockingValue(
+                patient_id=patient.id, blockingkey=models.BlockingKey.LAST_NAME.id, value="Smith"
+            )
+        )
         session.flush()
         assert len(patient.blocking_values) == 2
         mpi_service.delete_blocking_values_for_patient(session, patient)

--- a/tests/unit/routes/test_person_router.py
+++ b/tests/unit/routes/test_person_router.py
@@ -75,3 +75,40 @@ class TestUpdatePerson:
         assert resp.json()["person_reference_id"] == str(new_person.reference_id)
         assert resp.json()["person_reference_id"] == str(pat1.person.reference_id)
         assert resp.json()["person_reference_id"] == str(pat2.person.reference_id)
+
+
+class TestGetPerson:
+    def test_invalid_person_id(self, client):
+        response = client.get("/person/123")
+        assert response.status_code == 422
+
+    def test_invalid_person(self, client):
+        response = client.get(f"/person/{uuid.uuid4()}")
+        assert response.status_code == 404
+
+    def test_empty_patients(self, client):
+        person = models.Person()
+        client.session.add(person)
+        client.session.flush()
+
+        response = client.get(f"/person/{person.reference_id}")
+        assert response.status_code == 200
+        assert response.json() == {
+            "person_reference_id": str(person.reference_id),
+            "patient_reference_ids": [],
+        }
+
+    def test_with_patients(self, client):
+        person = models.Person()
+        pat1 = models.Patient(person=person, data={})
+        client.session.add(pat1)
+        pat2 = models.Patient(person=person, data={})
+        client.session.add(pat2)
+        client.session.flush()
+
+        response = client.get(f"/person/{person.reference_id}")
+        assert response.status_code == 200
+        assert response.json() == {
+            "person_reference_id": str(person.reference_id),
+            "patient_reference_ids": [str(pat1.reference_id), str(pat2.reference_id)],
+        }


### PR DESCRIPTION
## Description
Creating `GET /person/<ref-id>` and `GET /patient/<ref-id>` to retrieve info on the existing MPI data elements.

## Related Issues
closes #162 

## Additional Notes
Adding a testing helper context manager to count database queries, hoping this can be useful when we want to make assertions on how many SQL queries are issued.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
