### PR TITLE
Create function for probabilistic exact match

### DIFF
--- a/docs/site/reference.md
+++ b/docs/site/reference.md
@@ -174,7 +174,7 @@ existing Patient with the GIVEN_NAME of ["John", "D"].
     0.0. This is useful when performing probabilistic comparisons (which score a possible match's strength by
     accumulating a sum of link weights) on fields for which fuzzy similarity doesn't make sense, such as fields
     defined by an enum (e.g. Sex). Use the kwargs parameter to specify the log-odds ratios based on training.
-    Example: `{"kwargs": {"thresholds": {"FIRST_NAME": 0.8}, "log_odds": {"FIRST_NAME": 6.8}}}`
+    Example: `{"kwargs": {"log_odds": {"SEX": 6.8}}}`
 
 `func:recordlinker.linking.matchers.compare_probabilistic_fuzzy_match`
 

--- a/docs/site/reference.md
+++ b/docs/site/reference.md
@@ -166,6 +166,16 @@ existing Patient with the GIVEN_NAME of ["John", "D"].
     Use the `kwargs` parameter to specify the desired algorithm and thresholds.
     Example: `{"kwargs": {"similarity_measure": "levenshtein", "thresholds": {"FIRST_NAME": 0.8}}}`
 
+`func:recordlinker.linking.matchers.compare_probabilistic_exact_match`
+
+:   Determines if a Feature Field has the same value in two different patient records. If the two fields agree
+    exactly (i.e. are exactly the same), then the function returns the full extent of the log-odds weights for 
+    the particular field with which it was called. If the two fields do not exactly agree, the function returns
+    0.0. This is useful when performing probabilistic comparisons (which score a possible match's strength by
+    accumulating a sum of link weights) on fields for which fuzzy similarity doesn't make sense, such as fields
+    defined by an enum (e.g. Sex). Use the kwargs parameter to specify the log-odds ratios based on training.
+    Example: `{"kwargs": {"thresholds": {"FIRST_NAME": 0.8}, "log_odds": {"FIRST_NAME": 6.8}}}`
+
 `func:recordlinker.linking.matchers.compare_probabilistic_fuzzy_match`
 
 :   Similar to the above function, but uses a log-odds ratio to determine if the features are a match 

--- a/src/recordlinker/linking/matchers.py
+++ b/src/recordlinker/linking/matchers.py
@@ -47,6 +47,9 @@ class FeatureFunc(enum.Enum):
     COMPARE_MATCH_ANY = "func:recordlinker.linking.matchers.compare_match_any"
     COMPARE_MATCH_ALL = "func:recordlinker.linking.matchers.compare_match_all"
     COMPARE_FUZZY_MATCH = "func:recordlinker.linking.matchers.compare_fuzzy_match"
+    COMPARE_PROBABILISTIC_EXACT_MATCH = (
+        "func:recordlinker.linking.matchers.compare_probabilistic_exact_match"
+    )
     COMPARE_PROBABILISTIC_FUZZY_MATCH = (
         "func:recordlinker.linking.matchers.compare_probabilistic_fuzzy_match"
     )

--- a/tests/unit/linking/test_matchers.py
+++ b/tests/unit/linking/test_matchers.py
@@ -148,6 +148,53 @@ def test_compare_fuzzy_match():
         matchers.compare_fuzzy_match(record, pat1, schemas.Feature(attribute="first_name"))
 
 
+def test_compare_probabilistic_exact_match():
+    with pytest.raises(ValueError):
+        matchers.compare_probabilistic_exact_match(
+            schemas.PIIRecord(),
+            models.Patient(),
+            schemas.Feature(attribute=schemas.FeatureAttribute.SEX),
+        )
+    
+    rec = schemas.PIIRecord(
+        name=[{"given": ["John", "T"], "family": "Shepard"}],
+        birthDate="1980-11-7",
+    )
+    pat = models.Patient(
+        data={
+            "name": [{"given": ["John"], "family": "Shepard"}],
+            "birthDate": "1970-06-07",
+        }
+    )
+    log_odds = {
+        schemas.FeatureAttribute.FIRST_NAME.value: 4.0,
+        schemas.FeatureAttribute.LAST_NAME.value: 6.5,
+        schemas.FeatureAttribute.BIRTHDATE.value: 9.8,
+        schemas.FeatureAttribute.ADDRESS.value: 3.7,
+    }
+
+    assert (
+        matchers.compare_probabilistic_exact_match(
+            rec, pat, schemas.Feature(attribute=schemas.FeatureAttribute.FIRST_NAME), log_odds=log_odds
+        )
+        == 4.0
+    )
+
+    assert (
+        matchers.compare_probabilistic_exact_match(
+            rec, pat, schemas.Feature(attribute=schemas.FeatureAttribute.LAST_NAME), log_odds=log_odds
+        )
+        == 6.5
+    )
+
+    assert (
+        matchers.compare_probabilistic_exact_match(
+            rec, pat, schemas.Feature(attribute=schemas.FeatureAttribute.BIRTHDATE), log_odds=log_odds
+        )
+        == 0.0
+    )
+
+
 def test_compare_probabilistic_fuzzy_match():
     with pytest.raises(ValueError):
         matchers.compare_probabilistic_fuzzy_match(


### PR DESCRIPTION
## Description
This PR adds a matcher function for evaluating a probabilistic exact match. For a given feature field in two patient records, the matcher awards maximum log odds points for that field if the two fields are exactly the same and 0 points otherwise.

## Related Issues
#201 
