### PR TITLE
compare the entire GIVEN_NAME

### DIFF
--- a/docs/site/reference.md
+++ b/docs/site/reference.md
@@ -146,10 +146,13 @@ These are the functions that can be used to compare the values of two features t
 if they are a match or not.
 
 **Note**: When most features are compared, we are doing a 1 to 1 comparison (e.g. "M" == "M").
-However, some features have the ability to have multiple values (e.g. `GIVEN_NAME`), thus feature
+However, some features have the ability to have multiple values (e.g. `ADDRESS`), thus feature
 matching is designed to compare one list of values to another list of values.  For example, an
-incoming record could have a GIVEN_NAME of ["John", "Dean"] and we could be comparing them to an
-existing Patient with the GIVEN_NAME of ["John", "D"].
+incoming record could have a ADDRESS of
+[{"address": ["123 Main St", "apt 2"], "city": "Springfield", "state": "IL"}] and want to compare
+that to an existing Patient with the ADDRESS of
+[{"address": ["123 Main Street"], "city": "Springfield", "state": "IL"}, {"address": ["456 Elm St"], "state": "IL"}].
+In that case we'd want to evaluate "123 Main St" against both "123 Main Street" and "456 Elm St".
 
 `func:recordlinker.linking.matchers.compare_match_any`
 

--- a/src/recordlinker/schemas/pii.py
+++ b/src/recordlinker/schemas/pii.py
@@ -333,9 +333,8 @@ class PIIRecord(pydantic.BaseModel):
                     yield address.postal_code[:5]
         elif attribute == FeatureAttribute.GIVEN_NAME:
             for name in self.name:
-                for given in name.given:
-                    if given:
-                        yield given
+                if name.given:
+                    yield " ".join(name.given)
         elif attribute == FeatureAttribute.FIRST_NAME:
             for name in self.name:
                 # We only want the first given name for comparison

--- a/tests/unit/linking/test_matchers.py
+++ b/tests/unit/linking/test_matchers.py
@@ -72,7 +72,7 @@ def test_compare_match_any():
     assert matchers.compare_match_any(record, pat1, schemas.Feature(attribute=schemas.FeatureAttribute.BIRTHDATE))
     assert not matchers.compare_match_any(record, pat1, schemas.Feature(attribute=schemas.FeatureAttribute.ZIP))
 
-    assert matchers.compare_match_any(record, pat2, schemas.Feature(attribute=schemas.FeatureAttribute.GIVEN_NAME))
+    assert not matchers.compare_match_any(record, pat2, schemas.Feature(attribute=schemas.FeatureAttribute.GIVEN_NAME))
     assert not matchers.compare_match_any(record, pat2, schemas.Feature(attribute=schemas.FeatureAttribute.FIRST_NAME))
     assert matchers.compare_match_any(record, pat2, schemas.Feature(attribute=schemas.FeatureAttribute.LAST_NAME))
     assert not matchers.compare_match_any(record, pat2, schemas.Feature(attribute=schemas.FeatureAttribute.SEX))

--- a/tests/unit/schemas/test_pii.py
+++ b/tests/unit/schemas/test_pii.py
@@ -241,7 +241,7 @@ class TestPIIRecord:
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.CITY))) == ["Anytown", "Somecity"]
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.STATE))) == ["NY", "CA"]
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.ZIP))) == ["12345", "98765"]
-        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.GIVEN_NAME))) == ["John", "L", "Jane"]
+        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.GIVEN_NAME))) == ["John L", "Jane"]
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.FIRST_NAME))) == ["John", "Jane"]
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.LAST_NAME))) == ["Doe", "Smith"]
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == []
@@ -271,7 +271,18 @@ class TestPIIRecord:
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == ["BLACK"]
         record = pii.PIIRecord(race="white")
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == ["WHITE"]
-        
+
+    def test_feature_iter_given_name(self):
+        record = pii.PIIRecord(
+            name=[
+                pii.Name(family="Doe", given=["John", "L"], suffix=["suffix"]),
+                pii.Name(family="Smith", given=["Jon", "Lewis", "Doe"], suffix=["suffix2"]),
+            ],
+        )
+
+        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.GIVEN_NAME))) == ["John L", "Jon Lewis Doe"]
+        assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.FIRST_NAME))) == ["John", "Jon"]
+
 
     def test_blocking_keys_invalid(self):
         rec = pii.PIIRecord()


### PR DESCRIPTION
## Description
When comparing given name values, we should concatenate the entire given name before evaluation. Not doing so runs a risk of obtaining a high score when only the middle names/initials match.

## Related Issues
closes #199 

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
