### PR TITLE
removes deprecated API endpoints

### DIFF
--- a/src/recordlinker/routes/patient_router.py
+++ b/src/recordlinker/routes/patient_router.py
@@ -20,64 +20,6 @@ router = fastapi.APIRouter()
 
 
 @router.post(
-    "/{patient_reference_id}/person",
-    summary="Assign Patient to new Person",
-    status_code=fastapi.status.HTTP_201_CREATED,
-    deprecated=True,
-)
-def create_person(
-    patient_reference_id: uuid.UUID, session: orm.Session = fastapi.Depends(get_session)
-) -> schemas.PatientPersonRef:
-    """
-    **NOTE**: This endpoint is deprecated. Use the POST `/person` endpoint instead.
-
-    **NOTE**: This endpoint will be removed in v25.3.0.
-
-    Create a new Person in the MPI database and link the Patient to them.
-    """
-    patient = service.get_patients_by_reference_ids(session, patient_reference_id)[0]
-    if patient is None:
-        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
-
-    person = service.update_person_cluster(session, [patient], commit=False)
-    return schemas.PatientPersonRef(
-        patient_reference_id=patient.reference_id, person_reference_id=person.reference_id
-    )
-
-
-@router.patch(
-    "/{patient_reference_id}/person",
-    summary="Assign Patient to existing Person",
-    status_code=fastapi.status.HTTP_200_OK,
-    deprecated=True,
-)
-def update_person(
-    patient_reference_id: uuid.UUID,
-    data: schemas.PersonRef,
-    session: orm.Session = fastapi.Depends(get_session),
-) -> schemas.PatientPersonRef:
-    """
-    **NOTE**: This endpoint is deprecated. Use the PATCH `/person/{person_reference_id}` endpoint instead.
-
-    **NOTE**: This endpoint will be removed in v25.3.0.
-
-    Update the Person linked on the Patient.
-    """
-    patient = service.get_patients_by_reference_ids(session, patient_reference_id)[0]
-    if patient is None:
-        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
-
-    person = service.get_person_by_reference_id(session, data.person_reference_id)
-    if person is None:
-        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY)
-
-    person = service.update_person_cluster(session, [patient], person, commit=False)
-    return schemas.PatientPersonRef(
-        patient_reference_id=patient.reference_id, person_reference_id=person.reference_id
-    )
-
-
-@router.post(
     "/",
     summary="Create a patient record and link to an existing person",
     status_code=fastapi.status.HTTP_201_CREATED,
@@ -136,7 +78,8 @@ def get_patient(
         person_reference_id=patient.person.reference_id,
         record=patient.record,
         external_patient_id=patient.external_patient_id,
-        external_person_id=patient.external_person_id)
+        external_person_id=patient.external_person_id,
+    )
 
 
 @router.patch(

--- a/tests/unit/routes/test_patient_router.py
+++ b/tests/unit/routes/test_patient_router.py
@@ -10,63 +10,6 @@ import uuid
 from recordlinker import models
 
 
-class TestCreatePerson:
-    def test_invalid_reference_id(self, client):
-        response = client.post("/patient/123/person")
-        assert response.status_code == 422
-
-    def test_invalid_patient(self, client):
-        response = client.post(f"/patient/{uuid.uuid4()}/person")
-        assert response.status_code == 404
-
-    def test_create_person(self, client):
-        original_person = models.Person()
-        patient = models.Patient(person=original_person, data={})
-        client.session.add(patient)
-        client.session.flush()
-
-        resp = client.post(f"/patient/{patient.reference_id}/person")
-        assert resp.status_code == 201
-        assert resp.json()["patient_reference_id"] == str(patient.reference_id)
-        assert resp.json()["person_reference_id"] != str(original_person.reference_id)
-
-
-class TestUpdatePerson:
-    def test_invalid_reference_id(self, client):
-        response = client.patch("/patient/123/person")
-        assert response.status_code == 422
-
-    def test_invalid_patient(self, client):
-        data = {"person_reference_id": str(uuid.uuid4())}
-        response = client.patch(f"/patient/{uuid.uuid4()}/person", json=data)
-        assert response.status_code == 404
-
-    def test_invalid_person(self, client):
-        patient = models.Patient(person=models.Person(), data={})
-        client.session.add(patient)
-        client.session.flush()
-
-        data = {"person_reference_id": str(uuid.uuid4())}
-        response = client.patch(f"/patient/{patient.reference_id}/person", json=data)
-        assert response.status_code == 422
-
-    def test_update_person(self, client):
-        original_person = models.Person()
-        patient = models.Patient(person=original_person, data={})
-        client.session.add(patient)
-        client.session.flush()
-
-        new_person = models.Person()
-        client.session.add(new_person)
-        client.session.flush()
-
-        data = {"person_reference_id": str(new_person.reference_id)}
-        resp = client.patch(f"/patient/{patient.reference_id}/person", json=data)
-        assert resp.status_code == 200
-        assert resp.json()["patient_reference_id"] == str(patient.reference_id)
-        assert resp.json()["person_reference_id"] == str(new_person.reference_id)
-
-
 class TestCreatePatient:
     def test_missing_data(self, client):
         response = client.post("/patient")
@@ -197,9 +140,14 @@ class TestGetPatient:
         assert response.status_code == 404
 
     def test_get_patient(self, client):
-        patient = models.Patient(person=models.Person(), data={
-            "name": [{"given": ["John"], "family": "Doe"}],
-        }, external_patient_id="123", external_person_id="456")
+        patient = models.Patient(
+            person=models.Person(),
+            data={
+                "name": [{"given": ["John"], "family": "Doe"}],
+            },
+            external_patient_id="123",
+            external_person_id="456",
+        )
         client.session.add(patient)
         client.session.flush()
         response = client.get(f"/patient/{patient.reference_id}")
@@ -212,7 +160,9 @@ class TestGetPatient:
                 "birth_date": None,
                 "sex": None,
                 "address": [],
-                "name": [{"family": "Doe", "given": ["John"], "use": None, "prefix": [], "suffix": []}],
+                "name": [
+                    {"family": "Doe", "given": ["John"], "use": None, "prefix": [], "suffix": []}
+                ],
                 "telecom": [],
                 "race": None,
                 "identifiers": [],
@@ -220,4 +170,3 @@ class TestGetPatient:
             "external_patient_id": "123",
             "external_person_id": "456",
         }
-


### PR DESCRIPTION
## Description
Removes deprecated API endpoints in `/patient` now that they have been replaced by endpoints in the `/person` router.

## Related Issues
Fixes #160 
