### PR TITLE
Add endpoint for deleting orphaned persons

### DIFF
--- a/src/recordlinker/database/mpi_service.py
+++ b/src/recordlinker/database/mpi_service.py
@@ -370,7 +370,7 @@ def delete_persons(
         session.commit()
 
 
-def check_person_for_patients(session: orm.Session, person: models.Person) -> bool:
+def check_person_for_patients(session: orm.Session, person: models.Person) -> int | None:
     """
     Check if a Person has at least 1 associated Patient.
     """

--- a/src/recordlinker/database/mpi_service.py
+++ b/src/recordlinker/database/mpi_service.py
@@ -370,9 +370,9 @@ def delete_persons(
         session.commit()
 
 
-def check_person_for_patients(session: orm.Session, person: models.Person) -> int | None:
+def check_person_for_patients(session: orm.Session, person: models.Person) -> bool:
     """
     Check if a Person has at least 1 associated Patient.
     """
     query = select(literal(1)).filter(models.Patient.person_id == person.id).limit(1)
-    return session.execute(query).scalar()
+    return True if session.execute(query).scalar() is not None else False

--- a/src/recordlinker/database/mpi_service.py
+++ b/src/recordlinker/database/mpi_service.py
@@ -9,6 +9,7 @@ import typing
 import uuid
 
 from sqlalchemy import insert
+from sqlalchemy import literal
 from sqlalchemy import orm
 from sqlalchemy import select
 from sqlalchemy.sql import expression
@@ -367,3 +368,11 @@ def delete_persons(
         session.delete(person)
     if commit:
         session.commit()
+
+
+def check_person_for_patients(session: orm.Session, person: models.Person) -> bool:
+    """
+    Check if a Person has at least 1 associated Patient.
+    """
+    query = select(literal(1)).filter(models.Patient.person_id == person.id).limit(1)
+    return session.execute(query).scalar()

--- a/src/recordlinker/routes/person_router.py
+++ b/src/recordlinker/routes/person_router.py
@@ -180,7 +180,7 @@ def merge_person_clusters(
 def delete_empty_person(
     person_reference_id: uuid.UUID,
     session: orm.Session = fastapi.Depends(get_session),
-) -> None:
+):
     """
     Delete an empty Person from the MPI database.
     """

--- a/src/recordlinker/routes/person_router.py
+++ b/src/recordlinker/routes/person_router.py
@@ -207,7 +207,8 @@ def delete_empty_person(
         )
 
     # Check if the person has associated patients
-    if person.patients:
+    has_patients = service.check_person_for_patients(session, person)
+    if has_patients:
         raise fastapi.HTTPException(
             status_code=fastapi.status.HTTP_403_FORBIDDEN,
             detail=[

--- a/src/recordlinker/routes/person_router.py
+++ b/src/recordlinker/routes/person_router.py
@@ -176,6 +176,13 @@ def merge_person_clusters(
     "/{person_reference_id}",
     summary="Delete an empty Person",
     status_code=fastapi.status.HTTP_204_NO_CONTENT,
+    responses={
+        404: {"description": "Not Found", "model": schemas.ErrorResponse},
+        403: {
+            "description": "Forbidden",
+            "model": schemas.ErrorResponse,
+        },
+    },
 )
 def delete_empty_person(
     person_reference_id: uuid.UUID,
@@ -188,7 +195,16 @@ def delete_empty_person(
     person = service.get_person_by_reference_id(session, person_reference_id)
 
     if person is None:
-        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_404_NOT_FOUND,
+            detail=[
+                {
+                    "loc": ["path", "person_reference_id"],
+                    "msg": "Person not found",
+                    "type": "not_found",
+                }
+            ],
+        )
 
     # Check if the person has associated patients
     if person.patients:
@@ -197,7 +213,7 @@ def delete_empty_person(
             detail=[
                 {
                     "loc": ["path", "person_reference_id"],
-                    "msg": "Cannot delete Person because the id has associated Patients.",
+                    "msg": "Cannot delete Person because the ID has associated Patients.",
                     "type": "value_error",
                 }
             ],

--- a/src/recordlinker/schemas/__init__.py
+++ b/src/recordlinker/schemas/__init__.py
@@ -9,6 +9,8 @@ from .link import LinkResult
 from .link import MatchFhirResponse
 from .link import MatchResponse
 from .link import Prediction
+from .mpi import ErrorDetail
+from .mpi import ErrorResponse
 from .mpi import PatientCreatePayload
 from .mpi import PatientInfo
 from .mpi import PatientPersonRef
@@ -54,4 +56,7 @@ __all__ = [
     "PersonCluster",
     "PersonGroup",
     "PersonRefs",
+    "ErrorRespone",
+    "ErrorDetail",
+    "ErrorResponse",
 ]

--- a/src/recordlinker/schemas/__init__.py
+++ b/src/recordlinker/schemas/__init__.py
@@ -56,7 +56,6 @@ __all__ = [
     "PersonCluster",
     "PersonGroup",
     "PersonRefs",
-    "ErrorRespone",
     "ErrorDetail",
     "ErrorResponse",
 ]

--- a/src/recordlinker/schemas/mpi.py
+++ b/src/recordlinker/schemas/mpi.py
@@ -59,3 +59,22 @@ class PatientInfo(pydantic.BaseModel):
 class PersonInfo(pydantic.BaseModel):
     person_reference_id: uuid.UUID
     patient_reference_ids: list[uuid.UUID]
+
+
+class ErrorDetail(pydantic.BaseModel):
+    """
+    Error detail information.
+    """
+
+    loc: list[str]
+    msg: str
+    type: str
+
+
+class ErrorResponse(pydantic.BaseModel):
+    """
+
+    Error response for MPI operations.
+    """
+
+    detail: list[ErrorDetail]

--- a/tests/unit/database/test_mpi_service.py
+++ b/tests/unit/database/test_mpi_service.py
@@ -876,3 +876,19 @@ class TestDeletePersons:
         assert session.query(models.Person).count() == 1
         assert mpi_service.get_person_by_reference_id(session, person1.reference_id) is None
         assert mpi_service.get_person_by_reference_id(session, person2.reference_id) == person2
+
+
+class TestCheckPersonForPatients:
+    def test_check_person_for_patients(self, session):
+        person1 = models.Person()
+        patient1 = models.Patient(person=person1, data={})
+        person2 = models.Person()
+        patient2 = models.Patient(person=person2, data={})
+        session.add_all([patient1, patient2])
+        session.flush()
+        session.delete(patient2)
+
+        assert session.query(models.Patient).count() == 1
+        assert session.query(models.Person).count() == 2
+        assert mpi_service.check_person_for_patients(session, person1)
+        assert not mpi_service.check_person_for_patients(session, person2)

--- a/tests/unit/routes/test_person_router.py
+++ b/tests/unit/routes/test_person_router.py
@@ -199,3 +199,30 @@ class TestMergePersonClusters:
 
         assert response.status_code == 200
         assert response.json()["person_reference_id"] == str(person1.reference_id)
+
+
+class TestDeleteEmptyPerson:
+    def testDeleteEmptyPerson(self, client):
+        person = models.Person()
+        client.session.add(person)
+        client.session.flush()
+
+        response = client.delete(f"/person/{person.reference_id}")
+        assert response.status_code == 204
+
+    def testDeletePersonWithPatients(self, client):
+        person = models.Person()
+        patient = models.Patient(person=person, data={})
+        client.session.add(patient)
+        client.session.flush()
+
+        response = client.delete(f"/person/{person.reference_id}")
+        assert response.status_code == 403
+
+    def testInvalidPersonId(self, client):
+        response = client.delete("/person/123")
+        assert response.status_code == 422
+
+    def testInvalidPerson(self, client):
+        response = client.delete(f"/person/{uuid.uuid4()}")
+        assert response.status_code == 404


### PR DESCRIPTION
## Description
This PR adds an API endpoint for deleting persons who have no associated patients. It works by checking that the provided person_reference_id is valid and then checking if the person has any associated patients. Persons with associated patients are not deleted. 

## Related Issues
Addresses 1 of the 3 API endpoints listed in #163

## Additional Notes
The other API endpoints in #163 will be in follow-up PRs.
