### PR TITLE
Removed first 2 chars of authority from IDENTIFIER blocking key

### DIFF
--- a/docs/site/reference.md
+++ b/docs/site/reference.md
@@ -119,7 +119,7 @@ patient data and used during query retrieval. The following blocking key types a
 
 `IDENTIFIER` (ID: **10**)
 
-:  A colon separated string of the identifier type, first 2 characters of the authority and last 4 characters of the value.
+:  A colon separated string of the last 4 characters of the value and identifier type.
 
 
 ### Evaluation Functions

--- a/docs/site/reference.md
+++ b/docs/site/reference.md
@@ -119,7 +119,7 @@ patient data and used during query retrieval. The following blocking key types a
 
 `IDENTIFIER` (ID: **10**)
 
-:  A colon separated string of the last 4 characters of the value and identifier type.
+:  A colon separated string of the last 4 characters of the value and the identifier type.
 
 
 ### Evaluation Functions

--- a/src/recordlinker/schemas/pii.py
+++ b/src/recordlinker/schemas/pii.py
@@ -394,13 +394,9 @@ class PIIRecord(pydantic.BaseModel):
             # NOTE: we could optimize here and remove the dashes from the date
             vals.update(self.feature_iter(Feature(attribute=FeatureAttribute.BIRTHDATE)))
         elif key == models.BlockingKey.IDENTIFIER:
-            vals.update(
-                {
-                    f"{value_part[-4:]}:{authority_part[:2]}:{type_part}"
-                    for x in self.feature_iter(Feature(attribute=FeatureAttribute.IDENTIFIER))
-                    for value_part, authority_part, type_part in [x.split(":", 2)]
-                }
-            )
+            for ident in self.feature_iter(Feature(attribute=FeatureAttribute.IDENTIFIER)):
+                _value, _, _type = ident.split(":", 2)
+                vals.add(f"{_value[-4:]}:{_type}")
         elif key == models.BlockingKey.SEX:
             vals.update(self.feature_iter(Feature(attribute=FeatureAttribute.SEX)))
         elif key == models.BlockingKey.ZIP:

--- a/tests/unit/schemas/test_pii.py
+++ b/tests/unit/schemas/test_pii.py
@@ -358,9 +358,9 @@ class TestPIIRecord:
         rec = pii.PIIRecord(**{"identifiers": []})
         assert rec.blocking_keys(BlockingKey.IDENTIFIER) == set()
         rec = pii.PIIRecord(**{"identifiers": [{"type": "MR", "value": "123456789"}]})
-        assert rec.blocking_keys(BlockingKey.IDENTIFIER) == {"6789::MR"}
+        assert rec.blocking_keys(BlockingKey.IDENTIFIER) == {"6789:MR"}
         rec = pii.PIIRecord(**{"identifiers": [{"type": "MR", "value": "89"}]})
-        assert rec.blocking_keys(BlockingKey.IDENTIFIER) == {"89::MR"}
+        assert rec.blocking_keys(BlockingKey.IDENTIFIER) == {"89:MR"}
 
         # test multiple identifiers return correctly
         rec = pii.PIIRecord(
@@ -369,7 +369,7 @@ class TestPIIRecord:
                 pii.Identifier(type="SS", value="123456789"),
             ]
         )
-        assert rec.blocking_keys(BlockingKey.IDENTIFIER) == {"6789::MR", "6789::SS"}
+        assert rec.blocking_keys(BlockingKey.IDENTIFIER) == {"6789:MR", "6789:SS"}
 
     def test_blocking_keys_sex(self):
         rec = pii.PIIRecord(**{"gender": "M"})
@@ -494,13 +494,13 @@ class TestPIIRecord:
         rec = pii.PIIRecord(
             **{"identifiers": [{"type": "MR", "value": "123456789", "authority": "NY"}]}
         )
-        assert rec.blocking_keys(BlockingKey.IDENTIFIER) == {"6789:NY:MR"}
+        assert rec.blocking_keys(BlockingKey.IDENTIFIER) == {"6789:MR"}
 
         # test only get first 2 characters of authority for blocking
         rec = pii.PIIRecord(
             **{"identifiers": [{"type": "MR", "value": "123456789", "authority": "DMV"}]}
         )
-        assert rec.blocking_keys(BlockingKey.IDENTIFIER) == {"6789:DM:MR"}
+        assert rec.blocking_keys(BlockingKey.IDENTIFIER) == {"6789:MR"}
 
     def test_blocking_values(self):
         rec = pii.PIIRecord(
@@ -515,7 +515,7 @@ class TestPIIRecord:
             if key == BlockingKey.BIRTHDATE:
                 assert val == "1980-01-01"
             elif key == BlockingKey.IDENTIFIER:
-                assert val == "3456::MR"
+                assert val == "3456:MR"
             elif key == BlockingKey.FIRST_NAME:
                 assert val == "John"
             elif key == BlockingKey.LAST_NAME:


### PR DESCRIPTION
## Description
Changing IDENTIFIER blocking keys to `{value[-4:]}:{type}` format, authority is no longer present in the keys.

BREAKING CHANGE: The format of IDENTIFIER blocking keys has changed, and databases should be reset before upgrading.

## Related Issues
closes #226 

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
