### PR TITLE
Handle missing values in blocked MPI records

### DIFF
--- a/tests/unit/assets/possible_match_default_patient_bundle.json
+++ b/tests/unit/assets/possible_match_default_patient_bundle.json
@@ -84,16 +84,16 @@
         "birthDate": "1980-01-01",
         "gender": "male",
         "address": [
-            {
+          {
             "line": [
               "Bay 16",
               "Ward Sector 24"
             ],
-            "city": "Brooklyn",
-            "state": "New York",
-            "postalCode": "54321",
+            "city": "Boston",
+            "state": "Massachusetts",
+            "postalCode": "99999",
             "use": "home"
-            }
+          }
         ],
         "telecom": [
           {
@@ -134,7 +134,7 @@
         "birthDate": "1980-01-01",
         "gender": "male",
         "address": [
-            {
+          {
             "line": [
               "1234 Silversun Strip"
             ],


### PR DESCRIPTION
## Description
This PR adds a filter function to the `get_block_data` function in the `mpi_service`. This filter function removes from consideration all candidates from the MPI who are part of a person cluster containing a patient who satisfied blocking criteria, but which themselves have present values (i.e. are not missing fields) that disagree with incoming blocking keys. This will make matching more precise and reinforce validity in the blocking step.

## Related Issues
#231 

## Additional Notes
N/A

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
