### PR TITLE
Parse and validate two-digit dates

### DIFF
--- a/.github/workflows/check_smoke_tests.yml
+++ b/.github/workflows/check_smoke_tests.yml
@@ -80,7 +80,7 @@ jobs:
         done
       
         # Run smoke tests and print the response
-        JSON_BODY_1='{"record": {"birth_date": "2053-11-07", "sex": "M", "identifiers":[{"value": "123456789", "type": "MR"}], "name":[{"family":"Shepard", "given":["John"]}]}}'
+        JSON_BODY_1='{"record": {"birth_date": "2013-11-07", "sex": "M", "identifiers":[{"value": "123456789", "type": "MR"}], "name":[{"family":"Shepard", "given":["John"]}]}}'
         JSON_BODY_2='{"algorithm": "dibbs-default", "record": {"birth_date": "2000-12-06", "sex": "M", "identifiers":[{"value": "9876543210", "type": "MR"}], "name":[{"family":"Smith", "given":["William"]}]}}'
 
         #basic tests

--- a/docs/site/reference.md
+++ b/docs/site/reference.md
@@ -13,7 +13,12 @@ linkage evaluation phase. The following features are supported:
 
 `BIRTHDATE`
 
-:   The patient's birthdate (normalized to `YYYY-MM-DD`).
+:   The patient's birthdate (normalized to `YYYY-MM-DD`). If a birthdate with an ambiguous (i.e. 
+given as a two-digit year, rather than as four digits) year is provided, RecordLinker parses the 
+birthdate as `19XX` if the given year is after the two-digit year of the current calendar year 
+(`47`, for example, would become `1947`), and parses the birthdate as `20XX` otherwise (`08` and
+`25` would become `2008` and `2025`, respectively). If a patient's birthdate is given as a date 
+in the future, parsing the birthdate will generate an error message and result in a failure.
 
 `SEX`
 

--- a/src/recordlinker/schemas/pii.py
+++ b/src/recordlinker/schemas/pii.py
@@ -4,8 +4,7 @@ import json
 import re
 import typing
 
-import dateutil.parser
-from dateutil.parser import parserinfo
+from dateutil.parser import parse, parserinfo
 import pydantic
 
 from recordlinker import models
@@ -262,7 +261,7 @@ class PIIRecord(pydantic.BaseModel):
                         year -= 100
                 return year
         if value:
-            given_date = dateutil.parser.parse(str(value), LinkerParserInfo())
+            given_date = parse(str(value), LinkerParserInfo())
             if given_date > datetime.datetime.today():
                 raise ValueError("Dates cannot be in the future")
             if given_date < datetime.datetime(1850, 1, 1):

--- a/src/recordlinker/schemas/pii.py
+++ b/src/recordlinker/schemas/pii.py
@@ -247,11 +247,18 @@ class PIIRecord(pydantic.BaseModel):
         class LinkerParserInfo(parserinfo):
             def convertyear(self, year, *args):
                 """
-                Subclass method override for parser info function dedicatedo to
-                handling two-digit year strings.
+                Subclass method override for parser info function dedicated to
+                handling two-digit year strings. The Parser interprets any two
+                digit year string up to and including the last two digits of
+                the current year as the current century; any two-digit value 
+                above this number is interpreted as the preceding century.
+                E.g. '25' is parsed to '2025', but '74' becomes '1974'.
+                The Parser does not accept dates in the future, even if in 
+                the same calendar year.
                 """
                 # self._year is the current four-digit year
-                # self._century is leading two digits of self._year
+                # self._century is self._year with the tens and ones digits dropped, e.g.
+                # 19XX becomes 1900, 20XX becomes 2000
                 # implementation override follows template pattern in docs
                 # https://dateutil.readthedocs.io/en/latest/_modules/dateutil/parser/_parser.html#parserinfo.convertyear # noqa: E712
                 if year < 100:
@@ -264,9 +271,9 @@ class PIIRecord(pydantic.BaseModel):
         if value:
             given_date = parse(str(value), LinkerParserInfo())
             if given_date > datetime.datetime.today():
-                raise ValueError("Dates cannot be in the future")
+                raise ValueError("Birthdates cannot be in the future")
             if given_date < datetime.datetime(1850, 1, 1):
-                raise ValueError("Dates cannot be before 1850")
+                raise ValueError("Birthdates cannot be before 1850")
             return given_date
 
     @pydantic.field_validator("sex", mode="before")

--- a/src/recordlinker/schemas/pii.py
+++ b/src/recordlinker/schemas/pii.py
@@ -3,8 +3,8 @@ import enum
 import json
 import re
 import typing
-import pydantic
 
+import pydantic
 from dateutil.parser import parse
 from dateutil.parser import parserinfo
 

--- a/src/recordlinker/schemas/pii.py
+++ b/src/recordlinker/schemas/pii.py
@@ -3,9 +3,10 @@ import enum
 import json
 import re
 import typing
-
-from dateutil.parser import parse, parserinfo
 import pydantic
+
+from dateutil.parser import parse
+from dateutil.parser import parserinfo
 
 from recordlinker import models
 from recordlinker.schemas.identifier import Identifier

--- a/tests/unit/assets/patient_bundle_to_link_with_mpi.json
+++ b/tests/unit/assets/patient_bundle_to_link_with_mpi.json
@@ -31,7 +31,7 @@
             "use": "official"
           }
         ],
-        "birthDate": "2053-11-07",
+        "birthDate": "2013-11-07",
         "gender": "male",
         "address": [
           {
@@ -81,7 +81,7 @@
             "use": "official"
           }
         ],
-        "birthDate": "2053-11-07",
+        "birthDate": "2013-11-07",
         "gender": "male",
         "address": [
           {
@@ -132,7 +132,7 @@
             "use": "official"
           }
         ],
-        "birthDate": "2060-05-14",
+        "birthDate": "2020-05-14",
         "gender": "female",
         "address": [
           {
@@ -175,7 +175,7 @@
             "use": "official"
           }
         ],
-        "birthDate": "2053-11-07",
+        "birthDate": "2013-11-07",
         "gender": "male",
         "address": [
           {
@@ -225,7 +225,7 @@
             "use": "official"
           }
         ],
-        "birthDate": "2053-11-07",
+        "birthDate": "2013-11-07",
         "gender": "female",
         "address": [
           {
@@ -268,7 +268,7 @@
             "use": "official"
           }
         ],
-        "birthDate": "2053-11-07",
+        "birthDate": "2013-11-07",
         "gender": "female",
         "address": [
           {

--- a/tests/unit/assets/simple_patient_bundle_to_link_with_mpi.json
+++ b/tests/unit/assets/simple_patient_bundle_to_link_with_mpi.json
@@ -32,7 +32,7 @@
             "use": "official"
           }
         ],
-        "birthDate": "2053-11-07",
+        "birthDate": "2013-11-07",
         "gender": "male",
         "address": [
           {
@@ -83,7 +83,7 @@
             "use": "official"
           }
         ],
-        "birthDate": "2053-11-07",
+        "birthDate": "2013-11-07",
         "gender": "male",
         "address": [
           {
@@ -164,7 +164,7 @@
             "use": "official"
           }
         ],
-        "birthDate": "2060-05-14",
+        "birthDate": "2020-05-14",
         "gender": "female",
         "address": [
           {
@@ -217,7 +217,7 @@
             "use": "official"
           }
         ],
-        "birthDate": "2053-11-07",
+        "birthDate": "2013-11-07",
         "gender": "male",
         "address": [
           {
@@ -267,7 +267,7 @@
             "use": "official"
           }
         ],
-        "birthDate": "2053-11-07",
+        "birthDate": "2013-11-07",
         "gender": "female",
         "address": [
           {
@@ -311,7 +311,7 @@
             "use": "official"
           }
         ],
-        "birthDate": "2053-11-07",
+        "birthDate": "2013-11-07",
         "gender": "female",
         "address": [
           {

--- a/tests/unit/hl7/test_fhir.py
+++ b/tests/unit/hl7/test_fhir.py
@@ -59,7 +59,7 @@ def test_fhir_record_to_pii_record():
             },
         ],
         "name": [{"family": "Shepard", "given": ["John"], "use": "official"}],
-        "birthDate": "2053-11-07",
+        "birthDate": "2013-11-07",
         "gender": "male",
         "address": [
             {
@@ -112,7 +112,7 @@ def test_fhir_record_to_pii_record():
     assert pii_record.external_id == "f6a16ff7-4a31-11eb-be7b-8344edc8f36b"
     assert pii_record.name[0].family == "Shepard"
     assert pii_record.name[0].given == ["John"]
-    assert str(pii_record.birth_date) == "2053-11-07"
+    assert str(pii_record.birth_date) == "2013-11-07"
     assert str(pii_record.sex) == "M"
     assert pii_record.address[0].line == ["1234 Silversun Strip"]
     assert pii_record.address[0].city == "Boston"

--- a/tests/unit/schemas/test_pii.py
+++ b/tests/unit/schemas/test_pii.py
@@ -101,8 +101,6 @@ class TestPIIRecord:
         assert record.birth_date == datetime.date(1980, 1, 1)
         record = pii.PIIRecord()
         assert record.birth_date is None
-        record = pii.PIIRecord(birthdate="02-09-39")
-        assert record.birth_date == datetime.date(1939, 2, 9)
         record = pii.PIIRecord(birthdate="06-06-74")
         assert record.birth_date == datetime.date(1974, 6, 6)
         record = pii.PIIRecord(birthdate="12-19-08")

--- a/tests/unit/schemas/test_pii.py
+++ b/tests/unit/schemas/test_pii.py
@@ -101,10 +101,20 @@ class TestPIIRecord:
         assert record.birth_date == datetime.date(1980, 1, 1)
         record = pii.PIIRecord()
         assert record.birth_date is None
+        record = pii.PIIRecord(birthdate="02-09-39")
+        assert record.birth_date == datetime.date(1939, 2, 9)
+        record = pii.PIIRecord(birthdate="06-06-74")
+        assert record.birth_date == datetime.date(1974, 6, 6)
+        record = pii.PIIRecord(birthdate="12-19-08")
+        assert record.birth_date == datetime.date(2008, 12, 19)
 
     def test_parse_invalid_birthdate(self):
         with pytest.raises(pydantic.ValidationError):
             pii.PIIRecord(birth_date="1 de enero de 1980")
+        with pytest.raises(pydantic.ValidationError):
+            pii.PIIRecord(birth_date="01/01/3000")
+        with pytest.raises(pydantic.ValidationError):
+            pii.PIIRecord(birth_date="07/10/1543")
 
     def test_parse_sex(self):
         record = pii.PIIRecord(sex="M")


### PR DESCRIPTION
## Description
This PR does two things:
1. Adds more robust-handling of two-digit date strings, so that dates like `02/09/39` parse as 1939 rather than 2039,
2. Adds validation that sets boundaries around acceptable dates by not accepting dates before 1850 and after the current day.

## Related Issues
#237 

## Additional Notes
N/A
<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
