### PR TITLE
removing the unused SIMPLE_LINK parameter

### DIFF
--- a/tests/performance/rlpt.env
+++ b/tests/performance/rlpt.env
@@ -4,4 +4,3 @@ SPLIT_RECORDS=0  # 0: 1 API request per patient, 1: 1 API request per patient/en
 ITERATIONS=1  # Number of times to send the same data to the linkage API
 STATE="California"
 CITY="Los Angeles"
-USE_SIMPLE_LINK="true"

--- a/tests/performance/scripts/send_linkage_requests.sh
+++ b/tests/performance/scripts/send_linkage_requests.sh
@@ -35,9 +35,6 @@ for ((i=1; i<=ITERATIONS; i++)); do
             bundle=$(jq ".entry[0].resource.id = \"$uuid\"" <<< "$raw_bundle")
             # use the bundle to create a JSON payload for the linkage API
             payload="{\"bundle\": ${bundle}}"
-            # create the X-Use-Simple-Link header to indicate which schema the API
-            # should use to match the patient data
-            simple_header="X-Use-Simple-Link: ${USE_SIMPLE_LINK:-false}"
             # record the response to response.txt and capture the status code from STDOUT
             response=$(curl -s -o response.txt -w "%{http_code}" \
                 --header "Content-Type: application/json" --header "$simple_header" \


### PR DESCRIPTION
## Description
Minor clean up to remove some old code in our performance testing suite that isn't being used.

## Additional Notes
[X-Use-Simple-Link was a header value](https://github.com/CDCgov/RecordLinker/pull/66) that was used for performance testing the differences between the phdi codebase and Record Linker.  This was [removed many months ago](https://github.com/CDCgov/RecordLinker/pull/68) when the phdi code was removed from the codebase, but we forgot to update the performance tests.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
