### PR TITLE
allowing multiple race values

### DIFF
--- a/src/recordlinker/hl7/fhir.py
+++ b/src/recordlinker/hl7/fhir.py
@@ -33,7 +33,7 @@ def fhir_record_to_pii_record(fhir_record: dict) -> schemas.PIIRecord:
         "birthDate": fhir_record.get("birthDate"),
         "sex": fhir_record.get("gender"),
         "address": fhir_record.get("address", []),
-        "race": None,
+        "race": [],
         "telecom": fhir_record.get("telecom", []),
         "identifiers": [],
     }
@@ -61,7 +61,7 @@ def fhir_record_to_pii_record(fhir_record: dict) -> schemas.PIIRecord:
         if extension.get("url") == "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race":
             for ext in extension.get("extension", []):
                 if ext.get("url") == "ombCategory":
-                    val["race"] = ext.get("valueCoding", {}).get("display")
+                    val["race"].append(ext.get("valueCoding", {}).get("display"))
 
     return schemas.PIIRecord(**val)
 

--- a/tests/unit/hl7/test_fhir.py
+++ b/tests/unit/hl7/test_fhir.py
@@ -98,8 +98,21 @@ def test_fhir_record_to_pii_record():
                         "url": "ombCategory",
                         "valueCoding": {
                             "system": "urn:oid:2.16.840.1.113883.6.238",
-                            "code": "2106-3",
-                            "display": "White",
+                            "code": "2028-9",
+                            "display": "Asian",
+                        },
+                    }
+                ],
+            },
+            {
+                "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+                "extension": [
+                    {
+                        "url": "ombCategory",
+                        "valueCoding": {
+                            "system": "urn:oid:2.16.840.1.113883.6.238",
+                            "code": "2054-5",
+                            "display": "Black or African American",
                         },
                     }
                 ],
@@ -121,7 +134,7 @@ def test_fhir_record_to_pii_record():
     assert pii_record.address[0].county == "county"
     assert pii_record.telecom[0].value == "123-456-7890"
     assert pii_record.telecom[0].system == "phone"
-    assert str(pii_record.race) == "WHITE"
+    assert [str(r) for r in pii_record.race] == ["ASIAN", "BLACK"]
 
     # identifiers
     assert pii_record.identifiers[0].value == "1234567890"

--- a/tests/unit/routes/test_patient_router.py
+++ b/tests/unit/routes/test_patient_router.py
@@ -164,7 +164,7 @@ class TestGetPatient:
                     {"family": "Doe", "given": ["John"], "use": None, "prefix": [], "suffix": []}
                 ],
                 "telecom": [],
-                "race": None,
+                "race": [],
                 "identifiers": [],
             },
             "external_patient_id": "123",

--- a/tests/unit/schemas/test_pii.py
+++ b/tests/unit/schemas/test_pii.py
@@ -142,53 +142,53 @@ class TestPIIRecord:
 
     def test_parse_race(self):
         # testing verbose races
-        record = pii.PIIRecord(race="american indian or alaska native")
-        assert record.race == pii.Race.AMERICAN_INDIAN
-        record = pii.PIIRecord(race="black or african american")
-        assert record.race == pii.Race.BLACK
-        record = pii.PIIRecord(race="native hawaiian or other pacific islander")
-        assert record.race == pii.Race.HAWAIIAN
-        record = pii.PIIRecord(race="asked unknown")
-        assert record.race == pii.Race.ASKED_UNKNOWN
-        record = pii.PIIRecord(race="asked but unknown")
-        assert record.race == pii.Race.ASKED_UNKNOWN
-        record = pii.PIIRecord(race="unknown")
-        assert record.race == pii.Race.UNKNOWN
+        record = pii.PIIRecord(race=["american indian or alaska native"])
+        assert record.race == [pii.Race.AMERICAN_INDIAN]
+        record = pii.PIIRecord(race=["black or african american", "asian"])
+        assert record.race == [pii.Race.BLACK, pii.Race.ASIAN]
+        record = pii.PIIRecord(race=["native hawaiian or other pacific islander"])
+        assert record.race == [pii.Race.HAWAIIAN]
+        record = pii.PIIRecord(race=["asked unknown"])
+        assert record.race == [pii.Race.ASKED_UNKNOWN]
+        record = pii.PIIRecord(race=["asked but unknown"])
+        assert record.race == [pii.Race.ASKED_UNKNOWN]
+        record = pii.PIIRecord(race=["unknown"])
+        assert record.race == [pii.Race.UNKNOWN]
 
         # testing less verbose races
-        record = pii.PIIRecord(race="Asian")
-        assert record.race == pii.Race.ASIAN
-        record = pii.PIIRecord(race="Black")
-        assert record.race == pii.Race.BLACK
-        record = pii.PIIRecord(race="Hispanic")
-        assert record.race == pii.Race.OTHER
-        record = pii.PIIRecord(race="White")
-        assert record.race == pii.Race.WHITE
-        record = pii.PIIRecord(race="Other")
-        assert record.race == pii.Race.OTHER
-        record = pii.PIIRecord(race="Hawaiian")
-        assert record.race == pii.Race.HAWAIIAN
-        record = pii.PIIRecord(race="Pacific Islander")
-        assert record.race == pii.Race.HAWAIIAN
-        record = pii.PIIRecord(race="African American")
-        assert record.race == pii.Race.BLACK
-        record = pii.PIIRecord(race="American Indian")
-        assert record.race == pii.Race.AMERICAN_INDIAN
+        record = pii.PIIRecord(race=["Asian"])
+        assert record.race == [pii.Race.ASIAN]
+        record = pii.PIIRecord(race=["Black"])
+        assert record.race == [pii.Race.BLACK]
+        record = pii.PIIRecord(race=["Hispanic"])
+        assert record.race == [pii.Race.OTHER]
+        record = pii.PIIRecord(race=["White"])
+        assert record.race == [pii.Race.WHITE]
+        record = pii.PIIRecord(race=["Other"])
+        assert record.race == [pii.Race.OTHER]
+        record = pii.PIIRecord(race=["Hawaiian"])
+        assert record.race == [pii.Race.HAWAIIAN]
+        record = pii.PIIRecord(race=["Pacific Islander", "african american"])
+        assert record.race == [pii.Race.HAWAIIAN, pii.Race.BLACK]
+        record = pii.PIIRecord(race=["African American"])
+        assert record.race == [pii.Race.BLACK]
+        record = pii.PIIRecord(race=["American Indian"])
+        assert record.race == [pii.Race.AMERICAN_INDIAN]
 
         # testing other race
-        record = pii.PIIRecord(race="American")
-        assert record.race is pii.Race.OTHER
+        record = pii.PIIRecord(race=["American"])
+        assert record.race == [pii.Race.OTHER]
 
         # testing none result
         record = pii.PIIRecord()
-        assert record.race is None
+        assert record.race == []
 
     def test_feature_iter(self):
         record = pii.PIIRecord(
             external_id="99",
             birth_date="1980-2-1",
             sex="male",
-            race="unknown",
+            race=["unknown"],
             address=[
                 pii.Address(
                     line=[" 123 Main St"],
@@ -302,19 +302,19 @@ class TestPIIRecord:
         ) == ["123456789::SS"]
 
         # Other fields work okay, few more checks on difference race yield values
-        record = pii.PIIRecord(race="asked unknown")
+        record = pii.PIIRecord(race=["asked unknown"])
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == []
-        record = pii.PIIRecord(race="asked but unknown")
+        record = pii.PIIRecord(race=["asked but unknown"])
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == []
-        record = pii.PIIRecord(race="asian")
+        record = pii.PIIRecord(race=["asian"])
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == [
             "ASIAN"
         ]
-        record = pii.PIIRecord(race="african american")
+        record = pii.PIIRecord(race=["african american"])
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == [
             "BLACK"
         ]
-        record = pii.PIIRecord(race="white")
+        record = pii.PIIRecord(race=["white"])
         assert list(record.feature_iter(pii.Feature(attribute=pii.FeatureAttribute.RACE))) == [
             "WHITE"
         ]


### PR DESCRIPTION
## Description
Allowing for more than 1 race value to be specified per payload.  Also fixing a bug in the FHIR parser that only accepted the last race specified, now all race values are processed.

## Related Issues
closes #250 

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
