### PR TITLE
Add caching of RecordLinker image to smoke tests

### DIFF
--- a/.github/workflows/check_smoke_tests.yml
+++ b/.github/workflows/check_smoke_tests.yml
@@ -51,7 +51,6 @@ jobs:
     - name: Build and push RecordLinker image
       uses: docker/build-push-action@v3
       with:
-          context: ./recordlinker
           push: true
           tags: |
             ghcr.io/${{ env.REPO }}/rl-service:latest 

--- a/.github/workflows/check_smoke_tests.yml
+++ b/.github/workflows/check_smoke_tests.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
-      
+
     - name: Convert repository name to lowercase
       run: echo "REPO=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
@@ -58,9 +58,9 @@ jobs:
           tags: |
             ghcr.io/${{ env.REPO }}/rl-service:latest 
 
-    - name: Pull cached RecordLinker image from GitHub Container Registry
-      run: |
-        docker pull ghcr.io/${{ env.REPO }}/rl-service:latest || echo "No cached image found, skipping pull."
+    # - name: Pull cached RecordLinker image from GitHub Container Registry
+    #   run: |
+    #     docker pull ghcr.io/${{ env.REPO }}/rl-service:latest || echo "No cached image found, skipping pull."
     
     - name: Start RecordLinker Service and Run Smoke Tests
       run: |

--- a/.github/workflows/check_smoke_tests.yml
+++ b/.github/workflows/check_smoke_tests.yml
@@ -57,10 +57,6 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ env.REPO }}/rl-service:latest 
-
-    # - name: Pull cached RecordLinker image from GitHub Container Registry
-    #   run: |
-    #     docker pull ghcr.io/${{ env.REPO }}/rl-service:latest || echo "No cached image found, skipping pull."
     
     - name: Start RecordLinker Service and Run Smoke Tests
       run: |

--- a/.github/workflows/check_smoke_tests.yml
+++ b/.github/workflows/check_smoke_tests.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Convert repository name to lowercase
-      run: echo "PACKAGE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      run: echo "REPO=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3
@@ -47,27 +47,28 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Check if cached RecordLinker image exists in GitHub Container Registry
-      id: check_rl_image
-      run: |
-          docker pull ghcr.io/${{ env.PACKAGE_NAME }}/rl-service:latest || echo "No cached image found"
       
-    - name: Build and push RecordLinker Docker image if not cached
-      if: steps.check_rl_image.outcome == 'failure'
+    - name: Build and push RecordLinker image
+      uses: docker/build-push-action@v3
+      with:
+          context: ./recordlinker
+          push: true
+          tags: |
+            ghcr.io/${{ env.REPO }}/rl-service:latest 
+    
       run: |
         # Build the Docker image, tag it, & push to ghcr
         echo "Building and pushing RecordLinker Docker image..."
         docker build -t rl-service-image .
-        docker tag rl-service-image ghcr.io/${{ env.PACKAGE_NAME }}/rl-service:latest
-        docker push ghcr.io/${{ env.PACKAGE_NAME }}/rl-service:latest
+        docker tag rl-service-image ghcr.io/${{ env.REPO }}/rl-service:latest
+        docker push ghcr.io/${{ env.REPO }}/rl-service:latest
 
     - name: Check out repository
       uses: actions/checkout@v4
        
     - name: Pull cached RecordLinker image from GitHub Container Registry
       run: |
-        docker pull ghcr.io/${{ env.PACKAGE_NAME }}/rl-service:latest || echo "No cached image found, skipping pull."
+        docker pull ghcr.io/${{ env.REPO }}/rl-service:latest || echo "No cached image found, skipping pull."
     
     - name: Start RecordLinker Service and Run Smoke Tests
       run: |
@@ -85,7 +86,7 @@ jobs:
         docker run -d --name rl-service \
           --network="host" \
           -e DB_URI=$DB_URI \
-          ghcr.io/${{ env.PACKAGE_NAME }}/rl-service:latest  # Use the cached image
+          ghcr.io/${{ env.REPO }}/rl-service:latest  # Use the cached image
 
         # Wait for the RL Service to be healthy
         TRIES=5

--- a/.github/workflows/check_smoke_tests.yml
+++ b/.github/workflows/check_smoke_tests.yml
@@ -38,16 +38,37 @@ jobs:
           SA_PASSWORD: "YourStrong!Passw0rd"
 
     steps:
+    - name: Convert repository name to lowercase
+      run: echo "PACKAGE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Check if cached RecordLinker image exists in GitHub Container Registry
+      id: check_rl_image
+      run: |
+          docker pull ghcr.io/${{ env.PACKAGE_NAME }}/rl-service:latest || echo "No cached image found"
+      
+    - name: Build and push RecordLinker Docker image if not cached
+      if: steps.check_rl_image.outcome == 'failure'
+      run: |
+        # Build the Docker image, tag it, & push to ghcr
+        echo "Building and pushing RecordLinker Docker image..."
+        docker build -t rl-service-image .
+        docker tag rl-service-image ghcr.io/${{ env.PACKAGE_NAME }}/rl-service:latest
+        docker push ghcr.io/${{ env.PACKAGE_NAME }}/rl-service:latest
+
     - name: Check out repository
       uses: actions/checkout@v4
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Build RecordLinker Docker Image
+       
+    - name: Pull cached RecordLinker image from GitHub Container Registry
       run: |
-        docker build -t rl-service-image . 
-
+        docker pull ghcr.io/${{ env.PACKAGE_NAME }}/rl-service:latest || echo "No cached image found, skipping pull."
+    
     - name: Start RecordLinker Service and Run Smoke Tests
       run: |
         if [[ "${{ matrix.database }}" == "postgres" ]]; then
@@ -64,7 +85,7 @@ jobs:
         docker run -d --name rl-service \
           --network="host" \
           -e DB_URI=$DB_URI \
-          rl-service-image
+          ghcr.io/${{ env.PACKAGE_NAME }}/rl-service:latest  # Use the cached image
 
         # Wait for the RL Service to be healthy
         TRIES=5
@@ -125,4 +146,4 @@ jobs:
         -H "Content-Type: application/json")
 
         echo "Response: $RESPONSE_5"
-        echo "$RESPONSE_5" | grep -q "No algorithm found" 
+        echo "$RESPONSE_5" | grep -q "No algorithm found"

--- a/.github/workflows/check_smoke_tests.yml
+++ b/.github/workflows/check_smoke_tests.yml
@@ -56,12 +56,12 @@ jobs:
           tags: |
             ghcr.io/${{ env.REPO }}/rl-service:latest 
     
-      run: |
-        # Build the Docker image, tag it, & push to ghcr
-        echo "Building and pushing RecordLinker Docker image..."
-        docker build -t rl-service-image .
-        docker tag rl-service-image ghcr.io/${{ env.REPO }}/rl-service:latest
-        docker push ghcr.io/${{ env.REPO }}/rl-service:latest
+      # run: |
+      #   # Build the Docker image, tag it, & push to ghcr
+      #   echo "Building and pushing RecordLinker Docker image..."
+      #   docker build -t rl-service-image .
+      #   docker tag rl-service-image ghcr.io/${{ env.REPO }}/rl-service:latest
+      #   docker push ghcr.io/${{ env.REPO }}/rl-service:latest
 
     - name: Check out repository
       uses: actions/checkout@v4

--- a/.github/workflows/check_smoke_tests.yml
+++ b/.github/workflows/check_smoke_tests.yml
@@ -38,6 +38,9 @@ jobs:
           SA_PASSWORD: "YourStrong!Passw0rd"
 
     steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+      
     - name: Convert repository name to lowercase
       run: echo "REPO=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
@@ -54,7 +57,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ env.REPO }}/rl-service:latest 
-          
+
     - name: Pull cached RecordLinker image from GitHub Container Registry
       run: |
         docker pull ghcr.io/${{ env.REPO }}/rl-service:latest || echo "No cached image found, skipping pull."

--- a/.github/workflows/check_smoke_tests.yml
+++ b/.github/workflows/check_smoke_tests.yml
@@ -54,17 +54,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ env.REPO }}/rl-service:latest 
-    
-      # run: |
-      #   # Build the Docker image, tag it, & push to ghcr
-      #   echo "Building and pushing RecordLinker Docker image..."
-      #   docker build -t rl-service-image .
-      #   docker tag rl-service-image ghcr.io/${{ env.REPO }}/rl-service:latest
-      #   docker push ghcr.io/${{ env.REPO }}/rl-service:latest
-
-    - name: Check out repository
-      uses: actions/checkout@v4
-       
+          
     - name: Pull cached RecordLinker image from GitHub Container Registry
       run: |
         docker pull ghcr.io/${{ env.REPO }}/rl-service:latest || echo "No cached image found, skipping pull."


### PR DESCRIPTION
## Description
This PR addresses half of the caching issue outlined in ticket 224: ensuring that we use the cached the RecordLinker image when we run smoke tests to avoid hitting the limit on requests to DockerHub. 

After much tinkering, I added a `build-push-run` step to our smoke tests so now when you run them you should see that we use the image from ghcr for each smoke test instead of hitting `docker.io/library/python:3.12-slim` to build the service in each run.

## Related Issues
Fixes #224 

## Additional Notes
Getting the services to run from images in the GHCR has proven to be much more difficult, which is why I opted to split up the work on #244. At least we will have cut down the number of requests for RecordLinker by the 4/1 deadline.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
