### PR TITLE
dynamic next urls for patient/person routers

### DIFF
--- a/src/recordlinker/routes/patient_router.py
+++ b/src/recordlinker/routes/patient_router.py
@@ -95,13 +95,8 @@ def get_orphaned_patients(
             data=[], meta=schemas.PaginatedMetaData(next_cursor=None, next=None)
         )
     # Prepare the meta data
-    next_cursor = patients[-1].reference_id if len(patients) == limit else None
-    next_url = (
-        f"{request.base_url}patient/orphaned?limit={limit}&cursor={next_cursor}"
-        if next_cursor
-        else None
-    )
-
+    next_cursor: uuid.UUID | None = patients[-1].reference_id if len(patients) == limit else None
+    next_url: str | None = str(request.url.include_query_params(cursor=next_cursor)) if next_cursor else None
     return schemas.PaginatedRefs(
         data=[p.reference_id for p in patients if p.reference_id],
         meta=schemas.PaginatedMetaData(

--- a/src/recordlinker/routes/person_router.py
+++ b/src/recordlinker/routes/person_router.py
@@ -141,12 +141,8 @@ def get_orphaned_persons(
         )
 
     # Prepare the meta data
-    next_cursor = persons[-1].reference_id if len(persons) == limit else None
-    next_url = (
-        f"{request.base_url}person/orphaned?limit={limit}&cursor={next_cursor}"
-        if next_cursor
-        else None
-    )
+    next_cursor: uuid.UUID | None = persons[-1].reference_id if len(persons) == limit else None
+    next_url: str | None = str(request.url.include_query_params(cursor=next_cursor)) if next_cursor else None
 
     return schemas.PaginatedRefs(
         data=[p.reference_id for p in persons if p.reference_id],


### PR DESCRIPTION
## Description
removing the hard-coded next url paths for our orphaned patient and person routes, and replacing with versions that are dynamically generated.  The work on the roadshow concept is requiring us to reorganize our API url paths, which will in effect change the path for both of these routes.  Doing this dynamically makes it easier to encapsulate all those url path changes in main.py.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
