### PR TITLE
bugfix for null values

### DIFF
--- a/src/recordlinker/schemas/pii.py
+++ b/src/recordlinker/schemas/pii.py
@@ -59,8 +59,6 @@ class StrippedBaseModel(pydantic.BaseModel):
         if isinstance(v, str):
             return v.strip()
         return v
-
-
 class Feature(StrippedBaseModel):
     """
     The schema for a feature.
@@ -237,15 +235,16 @@ class Address(StrippedBaseModel):
         """
         Parse the line field into a list of strings with normalized street suffixes.
         """
-        normalized = []
-        for line in value:
-            parts = line.strip().split(" ")
-            # remove all non-alphanumeric characters and convert to uppercase
-            suffix = "".join(c for c in parts[-1] if c.isalnum()).upper()
-            if common := cls.ST_SUFFIXES.get(suffix):
-                # replace the suffix with the common suffix
-                parts[-1] = common
-            normalized.append(" ".join(parts))
+        normalized: list[str] = []
+        if value:
+            for line in value:
+                parts = line.strip().split(" ")
+                # remove all non-alphanumeric characters and convert to uppercase
+                suffix = "".join(c for c in parts[-1] if c.isalnum()).upper()
+                if common := cls.ST_SUFFIXES.get(suffix):
+                    # replace the suffix with the common suffix
+                    parts[-1] = common
+                normalized.append(" ".join(parts))
         return normalized
 
     @pydantic.field_validator("state", mode="before")
@@ -278,7 +277,7 @@ class Telecom(StrippedBaseModel):
     use: typing.Optional[str] = None
 
     @pydantic.model_validator(mode="after")
-    def validate_and_normalize_telecom(self):
+    def validate_and_normalize_telecom(self) -> typing.Self:
         """
         Validate and normalize the telecom record.
         """
@@ -340,7 +339,6 @@ class PIIRecord(StrippedBaseModel):
         Convert this PIIRecord into a data dict.
         """
         return self.to_dict(prune_empty=True)
-
 
     @pydantic.field_validator("external_id", mode="before")
     def parse_external_id(cls, value):
@@ -407,6 +405,8 @@ class PIIRecord(StrippedBaseModel):
         """
         Parse the race string into a race enum.
         """
+        if not value:
+            return []
         return [Race.parse(v) for v in value]
 
     def to_json(self, prune_empty: bool = False) -> str:

--- a/tests/unit/schemas/test_algorithm.py
+++ b/tests/unit/schemas/test_algorithm.py
@@ -86,27 +86,24 @@ class TestAlgorithmPass:
         apass = AlgorithmPass(
             blocking_keys=[],
             evaluators=[
-                {"feature": "LAST_NAME", "func": "func:recordlinker.linking.matchers.compare_probabilistic_fuzzy_match"}
+                {"feature": "LAST_NAME", "func": "COMPARE_PROBABILISTIC_FUZZY_MATCH"}
             ],
-            rule="func:recordlinker.linking.matchers.rule_probabilistic_match",
         )
         assert apass.label == "BLOCK_MATCH_last_name"
         apass = AlgorithmPass(
             blocking_keys=["ADDRESS"],
             evaluators=[
-                {"feature": "LAST_NAME", "func": "func:recordlinker.linking.matchers.compare_probabilistic_fuzzy_match"},
-                {"feature": "FIRST_NAME", "func": "func:recordlinker.linking.matchers.compare_probabilistic_fuzzy_match"},
+                {"feature": "LAST_NAME", "func": "COMPARE_PROBABILISTIC_FUZZY_MATCH"},
+                {"feature": "FIRST_NAME", "func": "COMPARE_PROBABILISTIC_FUZZY_MATCH"},
             ],
-            rule="func:recordlinker.linking.matchers.rule_probabilistic_match",
         )
         assert apass.label == "BLOCK_address_MATCH_last_name_first_name"
         apass = AlgorithmPass(
             label="custom-label",
             blocking_keys=[],
             evaluators=[
-                {"feature": "LAST_NAME", "func": "func:recordlinker.linking.matchers.compare_probabilistic_fuzzy_match"},
+                {"feature": "LAST_NAME", "func": "COMPARE_PROBABILISTIC_FUZZY_MATCH"}
             ],
-            rule="func:recordlinker.linking.matchers.rule_probabilistic_match",
         )
         assert apass.label == "custom-label"
 

--- a/tests/unit/schemas/test_identifier.py
+++ b/tests/unit/schemas/test_identifier.py
@@ -1,0 +1,39 @@
+"""
+unit.schemas.test_identifier.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This module contains the unit tests for the recordlinker.schemas.identifier module.
+"""
+import pytest
+
+from recordlinker.schemas import identifier
+
+
+class TestIdentifier:
+    def test_model_construct(self):
+        obj = identifier.Identifier.model_construct(type="MR", value="123456789", authority="NY")
+        assert obj.type == identifier.IdentifierType.MR
+        assert obj.value == "123456789"
+        assert obj.authority == "NY"
+
+        with pytest.raises(ValueError):
+            identifier.Identifier.model_construct(type="X", value="123456789", authority="NY")
+
+    def test_normalize_ssn_value(self):
+        with pytest.raises(ValueError):
+            identifier.Identifier(type=None, value="123-45-67890")
+
+        obj = identifier.Identifier(type="SS", value="123-45-6789")
+        assert obj.type == identifier.IdentifierType.SS
+        assert obj.value == "123-45-6789"
+        assert obj.authority is None
+
+        obj = identifier.Identifier(type="SS", value=" 123456789")
+        assert obj.type == identifier.IdentifierType.SS
+        assert obj.value == "123-45-6789"
+        assert obj.authority is None
+
+        obj = identifier.Identifier(type="MR", value="123456789")
+        assert obj.type == identifier.IdentifierType.MR
+        assert obj.value == "123456789"
+        assert obj.authority is None

--- a/tests/unit/schemas/test_pii.py
+++ b/tests/unit/schemas/test_pii.py
@@ -177,7 +177,7 @@ class TestPIIRecord:
         record = pii.PIIRecord(identifiers=[pii.Identifier(type="SS", value="123456789")])
         assert record.identifiers[0].value == "123-45-6789"
         record = pii.PIIRecord(identifiers=[pii.Identifier(type="SS", value="1-2-3")])
-        assert record.identifiers[0].value == ""
+        assert record.identifiers[0].value == "1-2-3"
         record = pii.PIIRecord()
         assert record.identifiers == []
 
@@ -222,6 +222,10 @@ class TestPIIRecord:
 
         # testing none result
         record = pii.PIIRecord()
+        assert record.race == []
+
+        # testing null race
+        record = pii.PIIRecord(race=None)
         assert record.race == []
 
     def test_feature_iter(self):
@@ -620,6 +624,10 @@ class TestAddress:
 
         address = pii.Address(line=[" 123 Main avenue "])
         assert address.line[0] == "123 Main AVE"
+
+        address = pii.Address(line=None, postal_code="12345")
+        assert address.line == []
+        assert address.postal_code == "12345"
 
     def test_parse_state(self):
         address = pii.Address(state=" New York")

--- a/tests/unit/schemas/test_pii.py
+++ b/tests/unit/schemas/test_pii.py
@@ -181,6 +181,9 @@ class TestPIIRecord:
         record = pii.PIIRecord()
         assert record.identifiers == []
 
+        with pytest.raises(ValueError):
+            pii.PIIRecord(identifiers=[pii.Identifier(type=None, value="123-45-6789")])
+
     def test_parse_race(self):
         # testing verbose races
         record = pii.PIIRecord(race=["american indian or alaska native"])


### PR DESCRIPTION
## Description
Fix to address server errors when a null value is send for `race`, `identifier.type` or `address.line`.

## Related Issues
closes #281 

## Additional Notes
Also fixing a broken test case from a bad merge.  https://github.com/CDCgov/RecordLinker/actions/runs/14340832961

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
