### PR TITLE
Update regex to match default labels

### DIFF
--- a/src/recordlinker/schemas/algorithm.py
+++ b/src/recordlinker/schemas/algorithm.py
@@ -46,7 +46,7 @@ class AlgorithmPass(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(from_attributes=True, use_enum_values=True)
 
     label: typing.Optional[str] = pydantic.Field(
-        None, pattern=r"^[a-z0-9]+(?:-[a-z0-9]+)*$", max_length=255
+        None, pattern=r"^[A-Za-z0-9]+(?:[_-][A-Za-z0-9]+)*$", max_length=255
     )
     description: typing.Optional[str] = None
     blocking_keys: list[BlockingKey] = pydantic.Field(
@@ -93,7 +93,7 @@ class Algorithm(pydantic.BaseModel):
 
     model_config = pydantic.ConfigDict(from_attributes=True, use_enum_values=True)
 
-    label: str = pydantic.Field(pattern=r"^[a-z0-9]+(?:-[a-z0-9]+)*$", max_length=255)
+    label: str = pydantic.Field(pattern=r"^[A-Za-z0-9]+(?:[_-][A-Za-z0-9]+)*$", max_length=255)
     description: typing.Optional[str] = None
     is_default: bool = False
     include_multiple_matches: bool = True


### PR DESCRIPTION
## Description
We set the default algorithm labels to be `BLOCK_feature1_feature2_MATCH_feature3_feature4` but the regex we included in the pydantic field validator did not allow for uppercase letters or underscores. This resulted in a `500` error when trying to retrieve the algorithms. The updated regex is a little more flexible and matches our default value pattern.

```
    | pydantic_core._pydantic_core.ValidationError: 2 validation errors for AlgorithmSummary
    | passes.0.label
    |   String should match pattern '^[a-z0-9]+(?:-[a-z0-9]+)*$' [type=string_pattern_mismatch, input_value='BLOCK_birthdate_identifi...CH_first_name_last_name', input_type=str]
    |     For further information visit https://errors.pydantic.dev/2.11/v/string_pattern_mismatch
    | passes.1.label
    |   String should match pattern '^[a-z0-9]+(?:-[a-z0-9]+)*$' [type=string_pattern_mismatch, input_value='BLOCK_zip_first_name_las...MATCH_address_birthdate', input_type=str]
    |     For further information visit https://errors.pydantic.dev/2.11/v/string_pattern_mismatch
```

## Related Issues

## Additional Notes


<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
