### PR TITLE
Use schemas.Algorithm for linking

### DIFF
--- a/src/recordlinker/assets/initial_algorithms.json
+++ b/src/recordlinker/assets/initial_algorithms.json
@@ -6,6 +6,7 @@
         "include_multiple_matches": true,
         "max_missing_allowed_proportion": 0.5,
         "missing_field_points_proportion": 0.5,
+        "skip_values": [],
         "passes": [
             {
                 "label": "BLOCK_birthdate_identifier_sex_MATCH_first_name_last_name",

--- a/src/recordlinker/models/mpi.py
+++ b/src/recordlinker/models/mpi.py
@@ -96,6 +96,12 @@ class BlockingKey(enum.Enum):
         """
         return self._value
 
+    def __str__(self) -> str:
+        """
+        Return the value of the enum as a string.
+        """
+        return self._value
+
 
 class BlockingValue(Base):
     __tablename__ = "mpi_blocking_value"

--- a/src/recordlinker/routes/link_router.py
+++ b/src/recordlinker/routes/link_router.py
@@ -11,7 +11,6 @@ import typing
 import fastapi
 import sqlalchemy.orm as orm
 
-from recordlinker import models
 from recordlinker import schemas
 from recordlinker.database import algorithm_service
 from recordlinker.database import get_session
@@ -21,7 +20,7 @@ from recordlinker.linking import link
 router = fastapi.APIRouter()
 
 
-def algorithm_or_422(db_session: orm.Session, label: str | None) -> models.Algorithm:
+def algorithm_or_422(db_session: orm.Session, label: str | None) -> schemas.Algorithm:
     """
     Get the Algorithm, or default if no label. Raise a 422 if no Algorithm can be found.
     """
@@ -35,7 +34,7 @@ def algorithm_or_422(db_session: orm.Session, label: str | None) -> models.Algor
             status_code=fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="No algorithm found",
         )
-    return algorithm
+    return schemas.Algorithm.model_validate(algorithm)
 
 
 def fhir_record_or_422(bundle: dict) -> schemas.PIIRecord:
@@ -70,7 +69,7 @@ def link_piirecord(
     check for matches with existing patient records If matches are found,
     returns the patient and person reference id's
     """
-    algorithm: models.Algorithm = algorithm_or_422(db_session, input.algorithm)
+    algorithm: schemas.Algorithm = algorithm_or_422(db_session, input.algorithm)
 
     (patient, person, results, match_grade) = link.link_record_against_mpi(
         record=input.record,
@@ -100,7 +99,7 @@ def link_fhir(
     check for matches with existing patient records If matches are found,
     returns the FHIR bundle with updated references to existing patients.
     """
-    algorithm: models.Algorithm = algorithm_or_422(db_session, input.algorithm)
+    algorithm: schemas.Algorithm = algorithm_or_422(db_session, input.algorithm)
     record: schemas.PIIRecord = fhir_record_or_422(input.bundle)
 
     (patient, person, results, match_grade) = link.link_record_against_mpi(
@@ -133,7 +132,7 @@ def match_piirecord(
     """
     Similar to the /link endpoint, but does not save the incoming data.
     """
-    algorithm: models.Algorithm = algorithm_or_422(db_session, input.algorithm)
+    algorithm: schemas.Algorithm = algorithm_or_422(db_session, input.algorithm)
 
     (patient, person, results, match_grade) = link.link_record_against_mpi(
         record=input.record,
@@ -160,7 +159,7 @@ def match_fhir(
     """
     Similar to the /link/fhir endpoint, but does not save the incoming data.
     """
-    algorithm: models.Algorithm = algorithm_or_422(db_session, input.algorithm)
+    algorithm: schemas.Algorithm = algorithm_or_422(db_session, input.algorithm)
     record: schemas.PIIRecord = fhir_record_or_422(input.bundle)
 
     (patient, person, results, match_grade) = link.link_record_against_mpi(

--- a/src/recordlinker/schemas/algorithm.py
+++ b/src/recordlinker/schemas/algorithm.py
@@ -49,7 +49,7 @@ class AlgorithmPass(pydantic.BaseModel):
     The schema for an algorithm pass record.
     """
 
-    model_config = pydantic.ConfigDict(from_attributes=True, use_enum_values=True)
+    model_config = pydantic.ConfigDict(from_attributes=True)
 
     label: typing.Optional[str] = pydantic.Field(
         None, pattern=r"^[A-Za-z0-9]+(?:[_-][A-Za-z0-9]+)*$", max_length=255
@@ -103,6 +103,13 @@ class AlgorithmPass(pydantic.BaseModel):
                 if key not in allowed:
                     raise ValueError(f"Invalid kwargs key: '{key}'. Allowed keys are: {allowed}")
         return value
+
+    @pydantic.field_serializer("blocking_keys")
+    def serialize_blocking_keys(self, keys: list[BlockingKey]) -> list[str]:
+        """
+        Serialize the blocking keys to a list of strings.
+        """
+        return [str(k) for k in keys]
 
 
 class SkipValue(pydantic.BaseModel):

--- a/src/recordlinker/schemas/algorithm.py
+++ b/src/recordlinker/schemas/algorithm.py
@@ -21,21 +21,27 @@ class Evaluator(pydantic.BaseModel):
     The schema for an evaluator record.
     """
 
-    model_config = pydantic.ConfigDict(from_attributes=True, use_enum_values=True)
+    model_config = pydantic.ConfigDict(from_attributes=True)
 
-    feature: str = pydantic.Field(json_schema_extra={"enum": Feature.all_options()})
+    feature: Feature = pydantic.Field(json_schema_extra={"enum": Feature.all_options()})
     func: matchers.FeatureFunc
 
     @pydantic.field_validator("feature", mode="before")
-    def validate_feature(cls, value):
+    def validate_feature(cls, value: str) -> Feature:
         """
         Validate the feature is a valid PII feature.
         """
         try:
-            Feature.parse(value)
+            return Feature.parse(value)
         except ValueError as e:
             raise ValueError(f"Invalid feature: '{value}'. {e}")
-        return value
+
+    @pydantic.field_serializer("func")
+    def serialize_func(self, value: matchers.FeatureFunc) -> str:
+        """
+        Serialize the func to a string.
+        """
+        return str(value)
 
 
 class AlgorithmPass(pydantic.BaseModel):

--- a/src/recordlinker/schemas/pii.py
+++ b/src/recordlinker/schemas/pii.py
@@ -60,6 +60,8 @@ class StrippedBaseModel(pydantic.BaseModel):
         if isinstance(v, str):
             return v.strip()
         return v
+
+
 class Feature(StrippedBaseModel):
     """
     The schema for a feature.
@@ -69,6 +71,15 @@ class Feature(StrippedBaseModel):
 
     suffix: typing.Optional[IdentifierType] = None
     attribute: FeatureAttribute
+
+    @pydantic.model_serializer()
+    def __str__(self):
+        """
+        Override the default model dump to create a single string for Feature.
+        """
+        if self.suffix:
+            return f"{self.attribute}:{self.suffix}"
+        return str(self.attribute)
 
     @classmethod
     def parse(cls, feature_string: str) -> typing.Self:

--- a/tests/algorithm/configurations/algorithm_configuration.json
+++ b/tests/algorithm/configurations/algorithm_configuration.json
@@ -5,6 +5,7 @@
     "include_multiple_matches": true,
     "max_missing_allowed_proportion": 0.5,
     "missing_field_points_proportion": 0.5,
+    "skip_values": [],
     "passes": [
         {
             "label": "BLOCK_birthdate_identifier_sex_MATCH_first_name_last_name",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 
 from recordlinker import database
 from recordlinker import main
-from recordlinker import models
+from recordlinker import schemas
 from recordlinker.utils import path as utils
 
 
@@ -76,7 +76,7 @@ def clean_test_database():
 def default_algorithm():
     for algo in utils.read_json("assets/initial_algorithms.json"):
         if algo["label"] == "dibbs-default":
-            return models.Algorithm.from_dict(**algo)
+            return schemas.Algorithm.model_validate(algo)
 
 
 @contextlib.contextmanager

--- a/tests/unit/routes/test_link_router.py
+++ b/tests/unit/routes/test_link_router.py
@@ -17,6 +17,7 @@ from fastapi import status
 
 from recordlinker import models
 from recordlinker import schemas
+from recordlinker.database import algorithm_service
 from recordlinker.hl7 import fhir
 from recordlinker.routes import link_router
 
@@ -338,7 +339,7 @@ class TestMatch:
         assert resp.json()["detail"] == "No algorithm found"
 
     def test_no_match(self, client, default_algorithm, patients):
-        client.session.add(default_algorithm)
+        algorithm_service.load_algorithm(client.session, default_algorithm)
         client.session.commit()
         resp = client.post(self.path(client), json={"record": patients[0].to_dict(True)})
         assert resp.status_code == status.HTTP_200_OK
@@ -350,7 +351,7 @@ class TestMatch:
         assert len(client.session.query(models.Patient).all()) == 0
 
     def test_match(self, client, default_algorithm, patients):
-        client.session.add(default_algorithm)
+        algorithm_service.load_algorithm(client.session, default_algorithm)
         client.session.commit()
         per1 = client.post(client.app.url_path_for("link-record"), json={"record": patients[0].to_dict(True)}).json()["person_reference_id"]
 
@@ -383,7 +384,7 @@ class TestMatchFHIR:
         assert resp.json()["detail"] == "No algorithm found"
 
     def test_no_match(self, client, default_algorithm, patient_bundles):
-        client.session.add(default_algorithm)
+        algorithm_service.load_algorithm(client.session, default_algorithm)
         client.session.commit()
         resp = client.post(self.path(client), json={"bundle": patient_bundles[0]})
         assert resp.status_code == status.HTTP_200_OK
@@ -396,7 +397,7 @@ class TestMatchFHIR:
         assert len(client.session.query(models.Patient).all()) == 0
 
     def test_match(self, client, default_algorithm, patient_bundles):
-        client.session.add(default_algorithm)
+        algorithm_service.load_algorithm(client.session, default_algorithm)
         client.session.commit()
         per1 = client.post(client.app.url_path_for("link-fhir"), json={"bundle": patient_bundles[0]}).json()["person_reference_id"]
 


### PR DESCRIPTION
## Description
Send a value of `schemas.Algorithm` and not `models.Algorithm` when linking records.

## Related Issues
closes #294 

## Additional Notes
When we save the Algorithm configuration to the database, we store many values as strings (eg blocking keys, features, functions, etc).  However, when using the configuration during linkage, we prefer using the enum, functions and objects those strings represent. Previously, this meant we have to cast the string values to its native type in the link and compare methods.

By converting the model data back to a schema.Algorithm object, we can do that casting one time before the linkage process kicks off.  This helps simplify our linkage logic a bit as it no longer needs to worry about how to cast strings back to their native data types.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
