### PR TITLE
Add suffix normalization

### DIFF
--- a/src/recordlinker/assets/suffixes.json
+++ b/src/recordlinker/assets/suffixes.json
@@ -1,0 +1,6 @@
+{
+    "Senior": "Sr",
+    "Sr.": "Sr",
+    "Junior": "Jr",
+    "Jr.": "Jr"
+}

--- a/tests/unit/schemas/test_pii.py
+++ b/tests/unit/schemas/test_pii.py
@@ -629,6 +629,12 @@ class TestName:
         name = pii.Name(family="Smith", given=["Joel", "Miller"], suffix=["Senior"])
         assert name.suffix == ["Sr"]
 
+        # Suffix is present but with weird casing
+        name = pii.Name(family="Smith", given=["Joel", "Miller"], suffix=["SR"])
+        assert name.suffix == ["Sr"]
+        name = pii.Name(family="Smith", given=["Joel", "Miller"], suffix=["jr"])
+        assert name.suffix == ["Jr"]
+
         # Suffix not listed
         name = pii.Name(family="Smith", given=["Joel", "Miller"], suffix=["invalid"])
         assert name.suffix == ["invalid"]

--- a/tests/unit/schemas/test_pii.py
+++ b/tests/unit/schemas/test_pii.py
@@ -619,6 +619,25 @@ class TestPIIRecord:
                 raise AssertionError(f"Unexpected key: {key}")
 
 
+class TestName:
+    def test_parse_suffix(self):
+        # No suffix specified
+        name = pii.Name(family="Smith", given=["Joel", "Miller"])
+        assert name.suffix == []
+
+        # Suffix is present in mapping
+        name = pii.Name(family="Smith", given=["Joel", "Miller"], suffix=["Senior"])
+        assert name.suffix == ["Sr"]
+
+        # Suffix not listed
+        name = pii.Name(family="Smith", given=["Joel", "Miller"], suffix=["invalid"])
+        assert name.suffix == ["invalid"]
+
+        # Multiple suffixes, mix of some in mapping and some not
+        name = pii.Name(family="Smith", given=["Joel", "Miller"], suffix=["Senior", "Jr.", "fake"])
+        assert name.suffix == ["Sr", "Jr", "fake"]
+
+
 class TestAddress:
     def test_parse_line(self):
         address = pii.Address(line=["123 Main St.", "Apt 2"])


### PR DESCRIPTION
## Description
This changeset adds a pydantic validator that parses and normalizes suffixes according to a predefined mapping. I've left the mapping in an assets file in case we want to add roman numeral standardization at some later date.

## Related Issues
Fixes #297 

## Additional Notes
I did some research on common suffixes in names in the US, and most results indicated it's pretty limited, just Junior, Senior, II, and III. It's easy to support roman numerals, as well as any other spelling or punctuated variants thereof, but given this I think leaving the suffixes we intend to support in an assets file (like with state abbreviations and street conventions) follows our established practice.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
