### PR TITLE
Prepend during blocking

### DIFF
--- a/docs/site/reference.md
+++ b/docs/site/reference.md
@@ -108,7 +108,7 @@ patient data and used during query retrieval. The following blocking key types a
 
 `FIRST_NAME` (ID: **5**)
 
-:   The first 4 characters of the patient's first name.
+:   The first 4 characters of the patient's first name. If the patient's name has a suffix, such as Jr. or Sr., then during blocking, a normalized abbreviation of this suffix is prepended to the patient's name before taking the first four characters. For example, "Michael Senior" would become "srmi" for blocking purposes.
 
 `LAST_NAME` (ID: **6**)
 

--- a/src/recordlinker/schemas/pii.py
+++ b/src/recordlinker/schemas/pii.py
@@ -460,10 +460,17 @@ class PIIRecord(StrippedBaseModel):
         data = self.to_json(prune_empty=prune_empty)
         return json.loads(data)
 
-    def feature_iter(self, feature: Feature) -> typing.Iterator[str]:
+    def feature_iter(self, feature: Feature, prepend_suffix: bool = False) -> typing.Iterator[str]:
         """
         Given a field name, return an iterator of all string values for that field.
-        Empty strings are not included in the iterator.
+        Empty strings are not included in the iterator. Includes an optional 
+        parameter that can be used when invoking `feature_iter` on the FIRST_NAME
+        field; if this parameter is true, the value yielded is the concatenation
+        `SUFFIX + FIRST_NAME`.
+
+        :param prepend_suffix: An optional boolean indicating whether a suffix 
+          should be prepended to a first name for blocking purposes. Has no
+          effect for features other than FIRST_NAME. 
         """
 
         if not isinstance(feature, Feature):
@@ -503,10 +510,18 @@ class PIIRecord(StrippedBaseModel):
                     yield normalize_text("".join(name.given))
         elif attribute == FeatureAttribute.FIRST_NAME:
             for name in self.name:
-                # We only want the first given name for comparison
+                # We only want the first suffix, and only if it's valid
+                # (i.e. an accepted output of normalization)
+                suffix: str = (name.suffix or [""])[0]
+                if suffix not in _PROCESSED_SUFFIXES:
+                    suffix = ""
+                # We only care about the first given name for comparisons
                 for given in name.given[0:1]:
                     if given:
-                        yield normalize_text(given)
+                        if prepend_suffix:
+                            yield normalize_text(suffix + given)
+                        else:
+                            yield normalize_text(given)
         elif attribute == FeatureAttribute.LAST_NAME:
             for name in self.name:
                 if name.family:
@@ -577,7 +592,7 @@ class PIIRecord(StrippedBaseModel):
             vals.update(self.feature_iter(Feature(attribute=FeatureAttribute.ZIP)))
         elif key == models.BlockingKey.FIRST_NAME:
             vals.update(
-                {x[:4] for x in self.feature_iter(Feature(attribute=FeatureAttribute.FIRST_NAME))}
+                {x[:4] for x in self.feature_iter(Feature(attribute=FeatureAttribute.FIRST_NAME), prepend_suffix=True)}
             )
         elif key == models.BlockingKey.LAST_NAME:
             vals.update(

--- a/tests/unit/schemas/test_pii.py
+++ b/tests/unit/schemas/test_pii.py
@@ -515,6 +515,38 @@ class TestPIIRecord:
         )
         assert rec.blocking_keys(BlockingKey.FIRST_NAME) == {"jane"}
 
+    def test_blocking_keys_first_name_with_suffixes(self):
+        # Single name struct, single suffix
+        rec = pii.PIIRecord(**{"name": [{"given": ["Joel"], "family": "Miller", "suffix": ["Senior"]}]})
+        assert rec.blocking_keys(BlockingKey.FIRST_NAME) == {"srjo"}
+
+        # Single name struct, invalid suffix --> ignored
+        rec = pii.PIIRecord(**{"name": [{"given": ["Joel"], "family": "Miller", "suffix": ["invalid"]}]})
+        assert rec.blocking_keys(BlockingKey.FIRST_NAME) == {"joel"}
+
+        # Single name struct, multiple givens, single suffix
+        rec = pii.PIIRecord(**{"name": [{"given": ["Joel", "Tommy", "Sarah"], "family": "Miller", "suffix": ["Senior"]}]})
+        assert rec.blocking_keys(BlockingKey.FIRST_NAME) == {"srjo"}
+
+        # Single name struct, multiple suffixes
+        rec = pii.PIIRecord(**{"name": [{"given": ["Joel"], "family": "Miller", "suffix": ["Senior", "Junior"]}]})
+        assert rec.blocking_keys(BlockingKey.FIRST_NAME) == {"srjo"}
+
+        # Multiple name structs, each with suffix
+        rec = pii.PIIRecord(**{"name": [
+            {"given": ["Joel"], "family": "Miller", "suffix": ["Senior"]},
+            {"given": ["Tommy"], "family": "Miller", "suffix": ["Junior"]}
+        ]})
+        assert rec.blocking_keys(BlockingKey.FIRST_NAME) == {"srjo", "jrto"}
+        
+        # Multiple name structs, some with suffixes and some without
+        rec = pii.PIIRecord(**{"name": [
+            {"given": ["Joel"], "family": "Miller", "suffix": [""]},
+            {"given": ["Tommy"], "family": "Miller", "suffix": ["Junior"]},
+            {"given": ["Sarah"], "family": "Miller", "suffix": []}
+        ]})
+        assert rec.blocking_keys(BlockingKey.FIRST_NAME) == {"joel", "jrto", "sara"}
+
     def test_blocking_keys_last_name_first_four(self):
         rec = pii.PIIRecord(**{"last_name": "Doe"})
         assert rec.blocking_keys(BlockingKey.LAST_NAME) == set()


### PR DESCRIPTION
## Description
This PR prepends normalized suffixes to first names during blocking. Following the convention of the existing `feature_iter` entry for First Name, only the first suffix is pulled, and _only_ if it has been normalized as a result of parsing. The least invasive way I found to make this change was an optional boolean flag on feature_iter proper, since otherwise in the blocking keys call we can't call feature_iter on First Name and have to basically repeat / reconstruct that code, but if that's preferable that's also okay with me.

## Related Issues
Closes #298 

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
