### PR TITLE
schema.AlgorithmContext

### DIFF
--- a/src/recordlinker/assets/initial_algorithms.json
+++ b/src/recordlinker/assets/initial_algorithms.json
@@ -3,10 +3,23 @@
         "label": "dibbs-default",
         "description": "The core DIBBs Log-Odds Algorithm. This default, recommended algorithm uses statistical correction to adjust the links between incoming records and previously processed patients (it does so by taking advantage of the fact that some fields are more informative than others—e.g., two records matching on MRN is stronger evidence that they should be linked than if the records matched on zip code). It can be used if additional granularity in matching links is desired. However, while the DIBBs Log-Odds Algorithm can create higher-quality links, it is dependent on statistical updating and pre-calculated population analysis, which requires some work on the part of the user. For those cases where additional precision or stronger matching criteria are required, the Log-Odds algorithm is detailed below.",
         "is_default": true,
-        "include_multiple_matches": true,
+        "algorithm_context": {
+          "include_multiple_matches": true,
+          "log_odds": [
+            { "feature": "ADDRESS", "value": 8.438284928858774 },
+            { "feature": "BIRTHDATE", "value": 10.126641103800338 },
+            { "feature": "CITY", "value": 2.438553006137189 },
+            { "feature": "FIRST_NAME", "value": 6.849475906891162 },
+            { "feature": "LAST_NAME", "value": 6.350720397426025 },
+            { "feature": "IDENTIFIER", "value": 0.3051262572525359 },
+            { "feature": "SEX", "value": 0.7510419059643679 },
+            { "feature": "STATE", "value": 0.022376768992488694 },
+            { "feature": "ZIP", "value": 4.975031471124867 }
+          ],
+          "skip_values": []
+        },
         "max_missing_allowed_proportion": 0.5,
         "missing_field_points_proportion": 0.5,
-        "skip_values": [],
         "passes": [
             {
                 "label": "BLOCK_birthdate_identifier_sex_MATCH_first_name_last_name",
@@ -38,17 +51,6 @@
                         "ADDRESS": 0.9,
                         "CITY": 0.92,
                         "ZIP": 0.95
-                    },
-                    "log_odds": {
-                        "ADDRESS": 8.438284928858774,
-                        "BIRTHDATE": 10.126641103800338,
-                        "CITY": 2.438553006137189,
-                        "FIRST_NAME": 6.849475906891162,
-                        "LAST_NAME": 6.350720397426025,
-                        "IDENTIFIER:MR": 0.3051262572525359,
-                        "SEX": 0.7510419059643679,
-                        "STATE": 0.022376768992488694,
-                        "ZIP": 4.975031471124867
                     }
                 }
             },
@@ -83,17 +85,6 @@
                         "ADDRESS": 0.9,
                         "CITY": 0.92,
                         "ZIP": 0.95
-                    },
-                    "log_odds": {
-                        "ADDRESS": 8.438284928858774,
-                        "BIRTHDATE": 10.126641103800338,
-                        "CITY": 2.438553006137189,
-                        "FIRST_NAME": 6.849475906891162,
-                        "LAST_NAME": 6.350720397426025,
-                        "IDENTIFIER:MR": 0.3051262572525359,
-                        "SEX": 0.7510419059643679,
-                        "STATE": 0.022376768992488694,
-                        "ZIP": 4.975031471124867
                     }
                 }
             }

--- a/src/recordlinker/linking/link.py
+++ b/src/recordlinker/linking/link.py
@@ -231,7 +231,7 @@ def link_record_against_mpi(
                 # get all candidate Patient records identified in blocking
                 # and the remaining Patient records in their Person clusters
                 pats = mpi_service.BlockData.get(
-                    session, cleaned_record, algorithm_pass, max_missing_allowed_proportion
+                    session, cleaned_record, algorithm_pass, context, max_missing_allowed_proportion
                 )
                 for pat in pats:
                     # convert the Patient model into a cleaned PIIRecord for comparison

--- a/src/recordlinker/linking/matchers.py
+++ b/src/recordlinker/linking/matchers.py
@@ -59,7 +59,6 @@ class AvailableKwarg(enum.Enum):
     SIMILARITY_MEASURE = "similarity_measure"
     THRESHOLD = "threshold"
     THRESHOLDS = "thresholds"
-    LOG_ODDS = "log_odds"
 
 
 def _get_fuzzy_params(col: str, **kwargs) -> tuple[SIMILARITY_MEASURES, float]:

--- a/src/recordlinker/linking/matchers.py
+++ b/src/recordlinker/linking/matchers.py
@@ -96,6 +96,7 @@ def compare_probabilistic_exact_match(
     record: PIIRecord,
     mpi_record: PIIRecord,
     key: Feature,
+    log_odds: float,
     missing_field_points_proportion: float,
     **kwargs: typing.Any,
 ) -> tuple[float, bool]:
@@ -113,6 +114,7 @@ def compare_probabilistic_exact_match(
     :param record: The incoming record to evaluate.
     :param mpi_record: The MPI record to compare against.
     :param key: The name of the column being evaluated (e.g. "city").
+    :param log_odds: The log-odds weight-points for this field
     :param missing_field_points_proportion: The proportion of log-odds points to
       award if one of the records is missing information in the given field.
     :param **kwargs: Optionally, a dictionary including specifications for
@@ -121,10 +123,6 @@ def compare_probabilistic_exact_match(
     :return: A tuple containing: a float of the score the feature comparison
       earned, and a boolean indicating whether one of the Fields was missing.
     """
-    log_odds = kwargs.get("log_odds", {}).get(str(key.attribute))
-    if log_odds is None:
-        raise ValueError(f"Log odds not found for feature {key}")
-
     incoming_record_fields = list(record.feature_iter(key))
     mpi_record_fields = list(mpi_record.feature_iter(key))
     if len(incoming_record_fields) == 0 or len(mpi_record_fields) == 0:
@@ -145,6 +143,7 @@ def compare_probabilistic_fuzzy_match(
     record: PIIRecord,
     mpi_record: PIIRecord,
     key: Feature,
+    log_odds: float,
     missing_field_points_proportion: float,
     **kwargs: typing.Any,
 ) -> tuple[float, bool]:
@@ -164,6 +163,7 @@ def compare_probabilistic_fuzzy_match(
     :param record: The incoming record to evaluate.
     :param mpi_record: The MPI record to compare against.
     :param key: The name of the column being evaluated (e.g. "city").
+    :param log_odds: The log-odds weight-points for this field
     :param missing_field_points_proportion: The proportion of log-odds points
       to award if one of the records is missing information in the given field.
     :param **kwargs: Optionally, a dictionary including specifications for
@@ -172,10 +172,6 @@ def compare_probabilistic_fuzzy_match(
     :return: A tuple containing: a float of the score the feature comparison
       earned, and a boolean indicating whether one of the Fields was missing.
     """
-    log_odds = kwargs.get("log_odds", {}).get(str(key.attribute))
-    if log_odds is None:
-        raise ValueError(f"Log odds not found for feature {key}")
-
     incoming_record_fields = list(record.feature_iter(key))
     mpi_record_fields = list(mpi_record.feature_iter(key))
     if len(incoming_record_fields) == 0 or len(mpi_record_fields) == 0:

--- a/src/recordlinker/models/algorithm.py
+++ b/src/recordlinker/models/algorithm.py
@@ -33,14 +33,13 @@ class Algorithm(Base):
     is_default: orm.Mapped[bool] = orm.mapped_column(default=False, index=True)
     label: orm.Mapped[str] = orm.mapped_column(sqltypes.String(255), unique=True)
     description: orm.Mapped[str] = orm.mapped_column(sqltypes.Text(), nullable=True)
-    include_multiple_matches: orm.Mapped[bool] = orm.mapped_column(sqltypes.Boolean, default=True)
     max_missing_allowed_proportion: orm.Mapped[float] = orm.mapped_column(
         sqltypes.Float, default=0.5
     )
     missing_field_points_proportion: orm.Mapped[float] = orm.mapped_column(
         sqltypes.Float, default=0.5
     )
-    skip_values: orm.Mapped[list[dict]] = orm.mapped_column(sqltypes.JSON, default=list)
+    algorithm_context: orm.Mapped[dict] = orm.mapped_column(sqltypes.JSON, default=dict)
     passes: orm.Mapped[list[dict]] = orm.mapped_column(sqltypes.JSON, default=list)
 
 

--- a/src/recordlinker/schemas/__init__.py
+++ b/src/recordlinker/schemas/__init__.py
@@ -1,4 +1,5 @@
 from .algorithm import Algorithm
+from .algorithm import AlgorithmContext
 from .algorithm import AlgorithmPass
 from .algorithm import AlgorithmSummary
 from .link import LinkFhirInput
@@ -32,6 +33,7 @@ from .seed import PersonGroup
 
 __all__ = [
     "Algorithm",
+    "AlgorithmContext",
     "AlgorithmPass",
     "AlgorithmSummary",
     "Feature",

--- a/src/recordlinker/schemas/algorithm.py
+++ b/src/recordlinker/schemas/algorithm.py
@@ -99,7 +99,6 @@ class AlgorithmContext(pydantic.BaseModel):
         """
         Initialize cache helpers for returning log odds values.
         """
-        self._log_odds_cache: dict[str, float | None] = {}
         self._log_odds_mapping: dict[str, float] = {str(o.feature): o.value for o in self.log_odds}
         return self
 
@@ -107,12 +106,7 @@ class AlgorithmContext(pydantic.BaseModel):
         """
         Get the log odds for a specific Feature or BlockingKey.
         """
-        key = str(value)
         result: float | None = None
-
-        result = self._log_odds_cache.get(key, None)
-        if result:
-            return result
 
         vals = value.values_to_match() if isinstance(value, Feature) else [str(value)]
         for val in vals:
@@ -120,7 +114,6 @@ class AlgorithmContext(pydantic.BaseModel):
             if result:
                 break
 
-        self._log_odds_cache[key] = result
         return result
 
 

--- a/src/recordlinker/schemas/pii.py
+++ b/src/recordlinker/schemas/pii.py
@@ -85,6 +85,14 @@ class Feature(StrippedBaseModel):
             return f"{self.attribute}:{self.suffix}"
         return str(self.attribute)
 
+    def values_to_match(self) -> typing.Iterator[str]:
+        """
+        Return an iterator of all possible values for this feature that can be used for comparison.
+        """
+        yield str(self)
+        if self.suffix:
+            yield str(self.attribute)
+
     @classmethod
     def parse(cls, feature_string: str) -> typing.Self:
         """

--- a/tests/algorithm/configurations/algorithm_configuration.json
+++ b/tests/algorithm/configurations/algorithm_configuration.json
@@ -2,10 +2,23 @@
     "label": "test-config",
     "description": "test algorithm configuration",
     "is_default": false,
-    "include_multiple_matches": true,
+    "algorithm_context": {
+      "include_multiple_matches": true,
+      "log_odds": [
+        { "feature": "ADDRESS", "value": 8.438284928858774 },
+        { "feature": "BIRTHDATE", "value": 10.126641103800338 },
+        { "feature": "CITY", "value": 2.438553006137189 },
+        { "feature": "FIRST_NAME", "value": 6.849475906891162 },
+        { "feature": "LAST_NAME", "value": 6.350720397426025 },
+        { "feature": "IDENTIFIER", "value": 0.3051262572525359 },
+        { "feature": "SEX", "value": 0.7510419059643679 },
+        { "feature": "STATE", "value": 0.022376768992488694 },
+        { "feature": "ZIP", "value": 4.975031471124867 }
+      ],
+      "skip_values": []
+    },
     "max_missing_allowed_proportion": 0.5,
     "missing_field_points_proportion": 0.5,
-    "skip_values": [],
     "passes": [
         {
             "label": "BLOCK_birthdate_identifier_sex_MATCH_first_name_last_name",
@@ -29,6 +42,7 @@
                 0.925
             ],
             "kwargs": {
+                "similarity_measure": "JaroWinkler",
                 "thresholds": {
                     "FIRST_NAME": 0.9,
                     "LAST_NAME": 0.9,
@@ -36,17 +50,6 @@
                     "ADDRESS": 0.9,
                     "CITY": 0.92,
                     "ZIP": 0.95
-                },
-                "log_odds": {
-                    "ADDRESS": 8.438284928858774,
-                    "BIRTHDATE": 10.126641103800338,
-                    "CITY": 2.438553006137189,
-                    "FIRST_NAME": 6.849475906891162,
-                    "LAST_NAME": 6.350720397426025,
-                    "IDENTIFIER:MR": 0.3051262572525359,
-                    "SEX": 0.7510419059643679,
-                    "STATE": 0.022376768992488694,
-                    "ZIP": 4.975031471124867
                 }
             }
         },
@@ -73,6 +76,7 @@
                 0.915
             ],
             "kwargs": {
+                "similarity_measure": "JaroWinkler",
                 "thresholds": {
                     "FIRST_NAME": 0.9,
                     "LAST_NAME": 0.9,
@@ -80,17 +84,6 @@
                     "ADDRESS": 0.9,
                     "CITY": 0.92,
                     "ZIP": 0.95
-                },
-                "log_odds": {
-                    "ADDRESS": 8.438284928858774,
-                    "BIRTHDATE": 10.126641103800338,
-                    "CITY": 2.438553006137189,
-                    "FIRST_NAME": 6.849475906891162,
-                    "LAST_NAME": 6.350720397426025,
-                    "IDENTIFIER:MR": 0.3051262572525359,
-                    "SEX": 0.7510419059643679,
-                    "STATE": 0.022376768992488694,
-                    "ZIP": 4.975031471124867
                 }
             }
         }

--- a/tests/unit/database/test_algorithm_service.py
+++ b/tests/unit/database/test_algorithm_service.py
@@ -64,6 +64,12 @@ class TestLoadAlgorithm:
             description="First algorithm",
             max_missing_allowed_proportion=0.5,
             missing_field_points_proportion=0.5,
+            algorithm_context={
+                "log_odds": [
+                    {"feature": "FIRST_NAME", "value": 6.8},
+                    {"feature": "ZIP", "value": 5.0},
+                ]
+            },
             passes=[
                 schemas.AlgorithmPass(
                     blocking_keys=["FIRST_NAME"],
@@ -107,6 +113,12 @@ class TestLoadAlgorithm:
             description="First algorithm",
             max_missing_allowed_proportion=0.5,
             missing_field_points_proportion=0.5,
+            algorithm_context={
+                "log_odds": [
+                    {"feature": "FIRST_NAME", "value": 6.8},
+                    {"feature": "ZIP", "value": 5.0},
+                ]
+            },
             passes=[
                 schemas.AlgorithmPass(
                     blocking_keys=["FIRST_NAME"],

--- a/tests/unit/linking/test_matchers.py
+++ b/tests/unit/linking/test_matchers.py
@@ -8,8 +8,6 @@ This module contains unit tests for the :mod:`~recordlinker.linking.matchers` mo
 import inspect
 import typing
 
-import pytest
-
 from recordlinker import models
 from recordlinker import schemas
 from recordlinker.linking import matchers

--- a/tests/unit/linking/test_matchers.py
+++ b/tests/unit/linking/test_matchers.py
@@ -20,12 +20,13 @@ class TestFeatureFunc:
         for rule in matchers.FeatureFunc:
             signature = inspect.signature(rule.callable())
             params = list(signature.parameters.values())
-            assert len(params) == 5
+            assert len(params) == 6
             assert params[0].annotation == schemas.PIIRecord
             assert params[1].annotation == schemas.PIIRecord
             assert params[2].annotation == schemas.Feature
             assert params[3].annotation is float
-            assert params[4].annotation == typing.Any
+            assert params[4].annotation is float
+            assert params[5].annotation == typing.Any
             assert signature.return_annotation == tuple[float, bool]
 
     def test_callable(self):
@@ -64,14 +65,6 @@ def test_get_fuzzy_params():
 def test_compare_probabilistic_exact_match():
     missing_points_proportion = 0.5
 
-    with pytest.raises(ValueError):
-        matchers.compare_probabilistic_exact_match(
-            schemas.PIIRecord(),
-            models.Patient(),
-            schemas.Feature(attribute=schemas.FeatureAttribute.SEX),
-            missing_points_proportion,
-        )
-
     rec = schemas.PIIRecord(
         name=[{"given": ["John", "T"], "family": "Shepard"}],
         birthDate="1980-11-7",
@@ -82,35 +75,29 @@ def test_compare_probabilistic_exact_match():
             "birthDate": "1970-06-07",
         }
     )
-    log_odds = {
-        schemas.FeatureAttribute.FIRST_NAME.value: 4.0,
-        schemas.FeatureAttribute.LAST_NAME.value: 6.5,
-        schemas.FeatureAttribute.BIRTHDATE.value: 9.8,
-        schemas.FeatureAttribute.ADDRESS.value: 3.7,
-    }
 
     assert matchers.compare_probabilistic_exact_match(
         rec,
         schemas.PIIRecord.from_patient(pat),
         schemas.Feature(attribute=schemas.FeatureAttribute.FIRST_NAME),
+        4.0,
         missing_points_proportion,
-        log_odds=log_odds,
     ) == (4.0, False)
 
     assert matchers.compare_probabilistic_exact_match(
         rec,
         schemas.PIIRecord.from_patient(pat),
         schemas.Feature(attribute=schemas.FeatureAttribute.LAST_NAME),
+        6.5,
         missing_points_proportion,
-        log_odds=log_odds,
     ) == (6.5, False)
 
     assert matchers.compare_probabilistic_exact_match(
         rec,
         schemas.PIIRecord.from_patient(pat),
         schemas.Feature(attribute=schemas.FeatureAttribute.BIRTHDATE),
+        9.8,
         missing_points_proportion,
-        log_odds=log_odds,
     ) == (0.0, False)
 
     # Now do a missing case
@@ -121,21 +108,13 @@ def test_compare_probabilistic_exact_match():
         rec,
         schemas.PIIRecord.from_patient(pat),
         schemas.Feature(attribute=schemas.FeatureAttribute.BIRTHDATE),
+        9.8,
         missing_points_proportion,
-        log_odds=log_odds,
     ) == (4.9, True)
 
 
 def test_compare_probabilistic_fuzzy_match():
     missing_points_proportion = 0.5
-
-    with pytest.raises(ValueError):
-        matchers.compare_probabilistic_fuzzy_match(
-            schemas.PIIRecord(),
-            models.Patient(),
-            schemas.Feature(attribute=schemas.FeatureAttribute.IDENTIFIER),
-            missing_points_proportion,
-        )
 
     rec = schemas.PIIRecord(
         name=[{"given": ["John"], "family": "Shepard"}],
@@ -149,27 +128,21 @@ def test_compare_probabilistic_fuzzy_match():
             "address": [{"line": ["asdfghjeki"]}],
         }
     )
-    log_odds = {
-        schemas.FeatureAttribute.FIRST_NAME.value: 4.0,
-        schemas.FeatureAttribute.LAST_NAME.value: 6.5,
-        schemas.FeatureAttribute.BIRTHDATE.value: 9.8,
-        schemas.FeatureAttribute.ADDRESS.value: 3.7,
-    }
 
     assert matchers.compare_probabilistic_fuzzy_match(
         rec,
         schemas.PIIRecord.from_patient(pat),
         schemas.Feature(attribute=schemas.FeatureAttribute.FIRST_NAME),
+        4.0,
         missing_points_proportion,
-        log_odds=log_odds,
     ) == (4.0, False)
 
     result = matchers.compare_probabilistic_fuzzy_match(
         rec,
         schemas.PIIRecord.from_patient(pat),
         schemas.Feature(attribute=schemas.FeatureAttribute.LAST_NAME),
+        6.5,
         missing_points_proportion,
-        log_odds=log_odds,
     )
     assert round(result[0], 3) == 6.129
     assert not result[1]
@@ -178,8 +151,8 @@ def test_compare_probabilistic_fuzzy_match():
         rec,
         schemas.PIIRecord.from_patient(pat),
         schemas.Feature(attribute=schemas.FeatureAttribute.BIRTHDATE),
+        9.8,
         missing_points_proportion,
-        log_odds=log_odds,
     )
     assert round(result[0], 3) == 7.859
     assert not result[1]
@@ -188,8 +161,8 @@ def test_compare_probabilistic_fuzzy_match():
         rec,
         schemas.PIIRecord.from_patient(pat),
         schemas.Feature(attribute=schemas.FeatureAttribute.ADDRESS),
+        3.7,
         missing_points_proportion,
-        log_odds=log_odds,
     )
     assert round(result[0], 3) == 0.0
     assert not result[1]
@@ -204,8 +177,8 @@ def test_compare_probabilistic_fuzzy_match():
         rec,
         schemas.PIIRecord.from_patient(pat),
         schemas.Feature(attribute=schemas.FeatureAttribute.FIRST_NAME),
+        4.0,
         missing_points_proportion,
-        log_odds=log_odds,
     )
     assert round(result[0], 3) == 2.0
     assert result[1]

--- a/tests/unit/routes/test_algorithm_router.py
+++ b/tests/unit/routes/test_algorithm_router.py
@@ -52,7 +52,10 @@ class TestGetAlgorithm:
             max_missing_allowed_proportion=0.5,
             missing_field_points_proportion=0.5,
             algorithm_context={
-                "log_odds": [{"feature": "FIRST_NAME", "value": 6.8}],
+                "log_odds": [
+                    {"feature": "FIRST_NAME", "value": 6.8},
+                    {"feature": "BIRTHDATE", "value": 10.0}
+                ],
                 "skip_values": [
                     {"feature": "*", "values": ["unknown"]},
                 ],
@@ -80,7 +83,10 @@ class TestGetAlgorithm:
             "missing_field_points_proportion": 0.5,
             "algorithm_context": {
                 "include_multiple_matches": True,
-                "log_odds": [{"feature": "FIRST_NAME", "value": 6.8}],
+                "log_odds": [
+                    {"feature": "FIRST_NAME", "value": 6.8},
+                    {"feature": "BIRTHDATE", "value": 10.0}
+                ],
                 "skip_values": [
                     {"feature": "*", "values": ["unknown"]},
                 ],
@@ -148,6 +154,12 @@ class TestCreateAlgorithm:
             "description": "Created algorithm",
             "max_missing_allowed_proportion": 0.5,
             "missing_field_points_proportion": 0.5,
+            "algorithm_context": {
+                "log_odds": [
+                    {"feature": "FIRST_NAME", "value": 6.8},
+                    {"feature": "BIRTHDATE", "value": 10.0}
+                ],
+            },
             "passes": [
                 {
                     "blocking_keys": [
@@ -240,6 +252,12 @@ class TestUpdateAlgorithm:
             "description": "Updated algorithm",
             "max_missing_allowed_proportion": 0.5,
             "missing_field_points_proportion": 0.5,
+            "algorithm_context": {
+                "log_odds": [
+                    {"feature": "FIRST_NAME", "value": 6.8},
+                    {"feature": "BIRTHDATE", "value": 10.0}
+                ],
+            },
             "passes": [
                 {
                     "blocking_keys": [

--- a/tests/unit/routes/test_algorithm_router.py
+++ b/tests/unit/routes/test_algorithm_router.py
@@ -24,10 +24,13 @@ class TestListAlgorithms:
                 "label": "default",
                 "is_default": True,
                 "description": "First algorithm",
-                "include_multiple_matches": True,
+                "algorithm_context": {
+                    "include_multiple_matches": True,
+                    "log_odds": [],
+                    "skip_values": [],
+                },
                 "max_missing_allowed_proportion": 0.5,
                 "missing_field_points_proportion": 0.5,
-                "skip_values": [],
                 "pass_count": 0,
             },
         ]
@@ -48,9 +51,12 @@ class TestGetAlgorithm:
             description="First algorithm",
             max_missing_allowed_proportion=0.5,
             missing_field_points_proportion=0.5,
-            skip_values=[
-                {"feature": "*", "values": ["unknown"]},
-            ],
+            algorithm_context={
+                "log_odds": [{"feature": "FIRST_NAME", "value": 6.8}],
+                "skip_values": [
+                    {"feature": "*", "values": ["unknown"]},
+                ],
+            },
             passes=[{
                 "blocking_keys": ["BIRTHDATE"],
                 "evaluators": [{
@@ -58,7 +64,7 @@ class TestGetAlgorithm:
                     "func": "COMPARE_PROBABILISTIC_FUZZY_MATCH",
                 }],
                 "possible_match_window": (0.75, 1.0),
-                "kwargs": {"similarity_measure": "JaroWinkler", "log_odds": {"FIRST_NAME": 6.8}},
+                "kwargs": {"similarity_measure": "JaroWinkler"},
             }],
         )
         client.session.add(algo)
@@ -70,12 +76,15 @@ class TestGetAlgorithm:
             "label": "default",
             "is_default": True,
             "description": "First algorithm",
-            "include_multiple_matches": True,
             "max_missing_allowed_proportion": 0.5,
             "missing_field_points_proportion": 0.5,
-            "skip_values": [
-                {"feature": "*", "values": ["unknown"]},
-            ],
+            "algorithm_context": {
+                "include_multiple_matches": True,
+                "log_odds": [{"feature": "FIRST_NAME", "value": 6.8}],
+                "skip_values": [
+                    {"feature": "*", "values": ["unknown"]},
+                ],
+            },
             "passes": [
                 {
                     "label": "BLOCK_birthdate_MATCH_first_name",
@@ -90,7 +99,6 @@ class TestGetAlgorithm:
                     "possible_match_window": [0.75, 1.0],
                     "kwargs": {
                         "similarity_measure": "JaroWinkler",
-                        "log_odds": {"FIRST_NAME": 6.8}
                     },
                 }
             ],

--- a/tests/unit/schemas/test_algorithm.py
+++ b/tests/unit/schemas/test_algorithm.py
@@ -11,6 +11,7 @@ import pytest
 from recordlinker.schemas.algorithm import Algorithm
 from recordlinker.schemas.algorithm import AlgorithmPass
 from recordlinker.schemas.algorithm import SkipValue
+from recordlinker.schemas.algorithm import LogOdd
 
 
 class TestAlgorithmPass:
@@ -143,6 +144,16 @@ class TestAlgorithmPass:
             possible_match_window=[0.8, 0.9]
         )
         assert apass.label == "custom-label"
+
+
+class TestLogOdd:
+    def test_invalid_feature(self):
+        with pytest.raises(pydantic.ValidationError):
+            LogOdd(feature="invalid", value=1.0)
+
+    def test_value_less_than_zero(self):
+        with pytest.raises(pydantic.ValidationError):
+            LogOdd(feature="FIRST_NAME", value=-1.0)
 
 
 class TestSkipValue:

--- a/tests/unit/schemas/test_algorithm.py
+++ b/tests/unit/schemas/test_algorithm.py
@@ -10,8 +10,8 @@ import pytest
 
 from recordlinker.schemas.algorithm import Algorithm
 from recordlinker.schemas.algorithm import AlgorithmPass
-from recordlinker.schemas.algorithm import SkipValue
 from recordlinker.schemas.algorithm import LogOdd
+from recordlinker.schemas.algorithm import SkipValue
 
 
 class TestAlgorithmPass:

--- a/tests/unit/schemas/test_algorithm.py
+++ b/tests/unit/schemas/test_algorithm.py
@@ -206,3 +206,53 @@ class TestAlgorithm:
                 ),
             ],
         )
+
+    def test_validate_log_odds_defined(self):
+        with pytest.raises(pydantic.ValidationError):
+            Algorithm(
+                label="test",
+                max_missing_allowed_proportion=0.5,
+                missing_field_points_proportion=0.5,
+                passes=[
+                    AlgorithmPass(
+                        blocking_keys=["BIRTHDATE"],
+                        evaluators=[],
+                        possible_match_window=(0.75, 1.0),
+                    )
+                ],
+            )
+        with pytest.raises(pydantic.ValidationError):
+            Algorithm(
+                label="test",
+                max_missing_allowed_proportion=0.5,
+                missing_field_points_proportion=0.5,
+                passes=[
+                    AlgorithmPass(
+                        blocking_keys=[],
+                        evaluators=[
+                            {"feature": "FIRST_NAME", "func": "COMPARE_PROBABILISTIC_FUZZY_MATCH"}
+                        ],
+                        possible_match_window=(0.75, 1.0),
+                    )
+                ],
+            )
+        Algorithm(
+            label="test",
+            max_missing_allowed_proportion=0.5,
+            missing_field_points_proportion=0.5,
+            algorithm_context={
+                "log_odds": [
+                    {"feature": "FIRST_NAME", "value": 7},
+                    {"feature": "BIRTHDATE", "value": 10},
+                ]
+            },
+            passes=[
+                AlgorithmPass(
+                    blocking_keys=["BIRTHDATE"],
+                    evaluators=[
+                        {"feature": "FIRST_NAME", "func": "COMPARE_PROBABILISTIC_FUZZY_MATCH"}
+                    ],
+                    possible_match_window=(0.75, 1.0),
+                )
+            ],
+        )

--- a/tests/unit/schemas/test_algorithm.py
+++ b/tests/unit/schemas/test_algorithm.py
@@ -113,7 +113,6 @@ class TestAlgorithmPass:
                 "similarity_measure": "JaroWinkler",
                 "thresholds": {"CITY": 0.95, "ADDRESS": 0.98},
                 "threshold": 0.9,
-                "log_odds": {"CITY": 12.0, "ADDRESS": 15.0},
             },
         )
 


### PR DESCRIPTION
## Description
Create AlgorithmContext nested schema object to store include_multiple_results, log_odds and skip_values.

## Related Issues
closes #293 

## Additional Notes
The `max_log_odds_points` parameter was removed from the compare method.  It's still required in the function, but now we need to retrieve the log_odds value for a feature BEFORE we call the matcher function (previously the matcher functions were retrieving this from the kwargs).  Since we're doing that in compare, it seemed simple enough to just make that a calculated value (summations are simple and quick).

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
