### PR TITLE
Add link and unlink endpoints

### DIFF
--- a/src/api/recordlinker/routes/demo_router.py
+++ b/src/api/recordlinker/routes/demo_router.py
@@ -105,7 +105,7 @@ def link_match(
     session_store.save_session(
         response,
         key="linked_status",
-        data=match_review_record,
+        data=match_review_record["linked"],
     )
     return match_review_record
 
@@ -137,6 +137,6 @@ def unlink_match(
     session_store.save_session(
         response,
         key="linked_status",
-        data=match_review_record,
+        data=match_review_record["linked"],
     )
     return match_review_record

--- a/src/api/recordlinker/routes/demo_router.py
+++ b/src/api/recordlinker/routes/demo_router.py
@@ -83,6 +83,7 @@ def get_match_review_records(
 def link_match(
     patient_reference_id: int,
     response: fastapi.Response,
+    request: fastapi.Request,
 ) -> schemas.demo.MatchReviewRecord:
     """
     Link demo records for match review.
@@ -101,12 +102,23 @@ def link_match(
         "person_id"
     ]
 
-    # Save session (modifies the real response)
+    # Load session data
+    d = (
+        session_store.load_session(
+            request,
+            key="linked_status",
+        )
+        or {}
+    )
+
+    # Update the session data & save
+    d.update({str(patient_reference_id): match_review_record["linked"]})
     session_store.save_session(
         response,
         key="linked_status",
-        data=match_review_record["linked"],
+        data=d,
     )
+
     return match_review_record
 
 
@@ -117,6 +129,7 @@ def link_match(
 def unlink_match(
     patient_reference_id: int,
     response: fastapi.Response,
+    request: fastapi.Request,
 ) -> schemas.demo.MatchReviewRecord:
     """
     Unlink demo records for match review.
@@ -133,10 +146,21 @@ def unlink_match(
     match_review_record["incoming_record"]["person_id"] = None
     # TODO: Remove potential match from the match_review_record since they were deemed not a match
 
-    # Save session
+    # Load session data
+    d = (
+        session_store.load_session(
+            request,
+            key="linked_status",
+        )
+        or {}
+    )
+
+    # Update the session data & save
+    d.update({str(patient_reference_id): match_review_record["linked"]})
     session_store.save_session(
         response,
         key="linked_status",
-        data=match_review_record["linked"],
+        data=d,
     )
+
     return match_review_record

--- a/src/api/recordlinker/routes/demo_router.py
+++ b/src/api/recordlinker/routes/demo_router.py
@@ -89,8 +89,8 @@ def get_demo_data(
     if linked_status:
         for record in data:
             patient_id = record["incoming_record"]["patient_id"]
-            if patient_id in linked_status:
-                record["linked"] = linked_status[patient_id]
+            if str(patient_id) in linked_status:
+                record["linked"] = linked_status[str(patient_id)]
 
     # Filter and sort the data based on the linked status
     filtered_sorted = filter_and_sort(data, status)

--- a/src/api/recordlinker/routes/demo_router.py
+++ b/src/api/recordlinker/routes/demo_router.py
@@ -104,7 +104,7 @@ def link_match(
     # Save session (modifies the real response)
     session_store.save_session(
         response,
-        key=f"linked_status_{patient_reference_id}",
+        key="linked_status",
         data=match_review_record,
     )
     return match_review_record
@@ -136,30 +136,7 @@ def unlink_match(
     # Save session
     session_store.save_session(
         response,
-        key=f"linked_status_{patient_reference_id}",
+        key="linked_status",
         data=match_review_record,
     )
     return match_review_record
-
-
-@router.get(
-    "/record/{patient_reference_id}/linked_status",
-    summary="Check linked status from session",
-)
-def get_linked_status(
-    patient_reference_id: int,
-    request: fastapi.Request,
-) -> schemas.demo.MatchReviewRecord:
-    """
-    Get linked status from session.
-    """
-    session_data = session_store.load_session(
-        request,
-        key=f"linked_status_{patient_reference_id}",
-    )
-    if session_data is None:
-        raise fastapi.HTTPException(
-            status_code=fastapi.status.HTTP_404_NOT_FOUND, detail="No session data found."
-        )
-
-    return schemas.demo.MatchReviewRecord.model_validate(session_data)

--- a/src/api/recordlinker/routes/demo_router.py
+++ b/src/api/recordlinker/routes/demo_router.py
@@ -11,6 +11,7 @@ import typing
 import fastapi
 
 from recordlinker import schemas
+from recordlinker import session_store
 from recordlinker.utils import path as utils
 
 router = fastapi.APIRouter()
@@ -73,3 +74,91 @@ def get_match_review_records(
     if match_review_record is None:
         raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
     return match_review_record
+
+
+@router.post(
+    "/record/{patient_reference_id}/link",
+    summary="Link demo records for match review",
+)
+def link_match(
+    patient_reference_id: int,
+    response: fastapi.Response,
+) -> schemas.demo.MatchReviewRecord:
+    """
+    Link demo records for match review.
+    """
+
+    match_review_record = next(
+        (d for d in data if d["incoming_record"]["patient_id"] == patient_reference_id), None
+    )
+    if match_review_record is None:
+        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
+
+    # Update the linked status
+    match_review_record["linked"] = True
+    # Update the incoming record with the person_id from the potential match
+    match_review_record["incoming_record"]["person_id"] = match_review_record["potential_match"][0][
+        "person_id"
+    ]
+
+    # Save session (modifies the real response)
+    session_store.save_session(
+        response,
+        key=f"linked_status_{patient_reference_id}",
+        data=match_review_record,
+    )
+    return match_review_record
+
+
+@router.post(
+    "/record/{patient_reference_id}/unlink",
+    summary="Unlink demo records for match review",
+)
+def unlink_match(
+    patient_reference_id: int,
+    response: fastapi.Response,
+) -> schemas.demo.MatchReviewRecord:
+    """
+    Unlink demo records for match review.
+    """
+
+    match_review_record = next(
+        (d for d in data if d["incoming_record"]["patient_id"] == patient_reference_id), None
+    )
+    if match_review_record is None:
+        raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
+
+    # Update the linked status
+    match_review_record["linked"] = False
+    # TODO: Remove potential match from the match_review_record since they were deemed not a match
+
+    # Save session
+    session_store.save_session(
+        response,
+        key=f"linked_status_{patient_reference_id}",
+        data=match_review_record,
+    )
+    return match_review_record
+
+
+@router.get(
+    "/record/{patient_reference_id}/linked_status",
+    summary="Check linked status from session",
+)
+def get_linked_status(
+    patient_reference_id: int,
+    request: fastapi.Request,
+) -> schemas.demo.MatchReviewRecord:
+    """
+    Get linked status from session.
+    """
+    session_data = session_store.load_session(
+        request,
+        key=f"linked_status_{patient_reference_id}",
+    )
+    if session_data is None:
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_404_NOT_FOUND, detail="No session data found."
+        )
+
+    return session_data

--- a/src/api/recordlinker/routes/demo_router.py
+++ b/src/api/recordlinker/routes/demo_router.py
@@ -162,4 +162,4 @@ def get_linked_status(
             status_code=fastapi.status.HTTP_404_NOT_FOUND, detail="No session data found."
         )
 
-    return session_data
+    return schemas.demo.MatchReviewRecord.model_validate(session_data)

--- a/src/api/recordlinker/routes/demo_router.py
+++ b/src/api/recordlinker/routes/demo_router.py
@@ -130,6 +130,7 @@ def unlink_match(
 
     # Update the linked status
     match_review_record["linked"] = False
+    match_review_record["incoming_record"]["person_id"] = None
     # TODO: Remove potential match from the match_review_record since they were deemed not a match
 
     # Save session

--- a/src/api/recordlinker/session_store.py
+++ b/src/api/recordlinker/session_store.py
@@ -14,7 +14,6 @@ def save_session(response: fastapi.Response, key: str, data: dict, **kwargs: typ
     response.set_cookie(
         key,
         value=serializer.dumps(data),
-        max_age=3600,
         domain=settings.session_cookie_domain,
         secure=settings.session_cookie_secure,
         httponly=True,

--- a/src/api/recordlinker/session_store.py
+++ b/src/api/recordlinker/session_store.py
@@ -14,7 +14,7 @@ def save_session(response: fastapi.Response, key: str, data: dict, **kwargs: typ
     response.set_cookie(
         key,
         value=serializer.dumps(data),
-        max_age=0,
+        max_age=3600,
         domain=settings.session_cookie_domain,
         secure=settings.session_cookie_secure,
         httponly=True,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -52,6 +52,7 @@ def client():
         # scope of the test
         main.api.dependency_overrides[database.get_session] = lambda: session
         with TestClient(main.app) as c:
+            c.cookies.clear()
             c.session = session
             yield c
 

--- a/tests/unit/routes/test_demo_router.py
+++ b/tests/unit/routes/test_demo_router.py
@@ -6,8 +6,15 @@ This module contains the unit tests for the recordlinker.routes.demo_router modu
 """
 
 import fastapi
+import pytest
 
 from recordlinker import session_store
+
+
+@pytest.fixture(autouse=True)
+def clear_client_cookies_after_each_test(client):
+    yield  # Let the test run
+    client.cookies.clear()  # Clean up all cookies after the test
 
 
 class TestGetMatchQueueRecordsEndpoint:
@@ -61,6 +68,30 @@ class TestGetMatchQueueRecordsEndpoint:
             ]
         }
 
+    # def test_get_records_with_session_update(self, client):
+    #     patient_reference_id = 1
+    #     # First call — no session yet
+    #     response = client.get("/api/demo/record")
+    #     assert response.status_code == 200
+    #     assert response.json()[0]["linked"] is None
+
+    #     # Simulate a session store update
+    #     dummy_response = fastapi.Response()
+    #     session_store.save_session(
+    #         dummy_response, key="linked_status", data={str(patient_reference_id): True}
+    #     )
+
+    #     # Extract Set-Cookie header from response and apply it to client
+    #     set_cookie_header = dummy_response.headers["set-cookie"]
+    #     cookie_parts = set_cookie_header.split(";")[0]
+    #     key, value = cookie_parts.split("=", 1)
+    #     client.cookies.set(key, value)  # Apply the cookie to the test client
+
+    #     # Second call — session should now be updated
+    #     response = client.get("/api/demo/record")
+    #     assert response.status_code == 200
+    #     assert response.json()[0]["linked"] is True
+
 
 class TestGetMatchReviewRecords:
     def test_get_records(self, client):
@@ -99,7 +130,7 @@ class TestGetMatchReviewRecords:
         # Simulate a session store update
         dummy_response = fastapi.Response()
         session_store.save_session(
-            dummy_response, key="linked_status", data={patient_reference_id: True}
+            dummy_response, key="linked_status", data={str(patient_reference_id): True}
         )
 
         # Extract Set-Cookie header from response and apply it to client

--- a/tests/unit/routes/test_demo_router.py
+++ b/tests/unit/routes/test_demo_router.py
@@ -104,7 +104,7 @@ class TestLinkMatch:
             session_store.load_session(
                 response,
                 key="linked_status",
-            )
+            )[str(patient_reference_id)]
             is True
         )
 
@@ -141,7 +141,7 @@ class TestUnlinkMatch:
             session_store.load_session(
                 response,
                 key="linked_status",
-            )
+            )[str(patient_reference_id)]
             is False
         )
 

--- a/tests/unit/routes/test_demo_router.py
+++ b/tests/unit/routes/test_demo_router.py
@@ -100,16 +100,12 @@ class TestLinkMatch:
             == response.json()["potential_match"][0]["person_id"]
         )
 
-        session_data = session_store.load_session(
-            response,
-            key="linked_status",
-        )
-
-        assert session_data["incoming_record"]["patient_id"] == patient_reference_id
-        assert session_data["linked"] is True
         assert (
-            session_data["incoming_record"]["person_id"]
-            == session_data["potential_match"][0]["person_id"]
+            session_store.load_session(
+                response,
+                key="linked_status",
+            )
+            is True
         )
 
     def test_link_match_invalid_id(self, client):
@@ -141,13 +137,13 @@ class TestUnlinkMatch:
         assert response.json()["linked"] is False
         assert response.json()["incoming_record"]["person_id"] is None
 
-        session_data = session_store.load_session(
-            response,
-            key="linked_status",
+        assert (
+            session_store.load_session(
+                response,
+                key="linked_status",
+            )
+            is False
         )
-        assert session_data["incoming_record"]["patient_id"] == patient_reference_id
-        assert session_data["linked"] is False
-        assert session_data["incoming_record"]["person_id"] is None
 
     def test_unlink_match_invalid_id(self, client):
         response = client.post("/api/demo/record/invalid/unlink")

--- a/tests/unit/routes/test_demo_router.py
+++ b/tests/unit/routes/test_demo_router.py
@@ -5,6 +5,8 @@ unit.routes.test_demo_router.py
 This module contains the unit tests for the recordlinker.routes.demo_router module.
 """
 
+from recordlinker import session_store
+
 
 class TestGetMatchQueueRecordsEndpoint:
     def test_get_records(self, client):
@@ -98,6 +100,18 @@ class TestLinkMatch:
             == response.json()["potential_match"][0]["person_id"]
         )
 
+        session_data = session_store.load_session(
+            response,
+            key="linked_status",
+        )
+
+        assert session_data["incoming_record"]["patient_id"] == patient_reference_id
+        assert session_data["linked"] is True
+        assert (
+            session_data["incoming_record"]["person_id"]
+            == session_data["potential_match"][0]["person_id"]
+        )
+
     def test_link_match_invalid_id(self, client):
         response = client.post("/api/demo/record/invalid/link")
         assert response.status_code == 422
@@ -127,6 +141,14 @@ class TestUnlinkMatch:
         assert response.json()["linked"] is False
         assert response.json()["incoming_record"]["person_id"] is None
 
+        session_data = session_store.load_session(
+            response,
+            key="linked_status",
+        )
+        assert session_data["incoming_record"]["patient_id"] == patient_reference_id
+        assert session_data["linked"] is False
+        assert session_data["incoming_record"]["person_id"] is None
+
     def test_unlink_match_invalid_id(self, client):
         response = client.post("/api/demo/record/invalid/unlink")
         assert response.status_code == 422
@@ -145,39 +167,3 @@ class TestUnlinkMatch:
         response = client.post("/api/demo/record/9/unlink")
         assert response.status_code == 404
         assert response.json() == {"detail": "Not Found"}
-
-
-class TestGetLinkStatusFromSession:
-    def test_get_link_status(self, client):
-        patient_reference_id = 1
-        post_response = client.post(f"/api/demo/record/{patient_reference_id}/link")
-        assert post_response.status_code == 200
-
-        get_response = client.get(f"/api/demo/record/{patient_reference_id}/linked_status")
-        assert get_response.status_code == 200
-        assert get_response.json()["linked"] is True
-
-        post_response = client.post(f"/api/demo/record/{patient_reference_id}/unlink")
-        assert post_response.status_code == 200
-        get_response = client.get(f"/api/demo/record/{patient_reference_id}/linked_status")
-        assert get_response.status_code == 200
-        assert get_response.json()["linked"] is False
-
-    def test_get_link_status_invalid_id(self, client):
-        response = client.get("/api/demo/record/invalid/linked_status")
-        assert response.status_code == 422
-        assert response.json() == {
-            "detail": [
-                {
-                    "type": "int_parsing",
-                    "loc": ["path", "patient_reference_id"],
-                    "msg": "Input should be a valid integer, unable to parse string as an integer",
-                    "input": "invalid",
-                }
-            ]
-        }
-
-    def test_get_link_status_missing_id(self, client):
-        response = client.get("/api/demo/record/9/linked_status")
-        assert response.status_code == 404
-        assert response.json() == {"detail": "No session data found."}


### PR DESCRIPTION
## Description
This PR adds 2 new endpoints: 
1) "link" endpoint to update the `linked_status` to `True` when a user clicks on the "link" button. It also updates the `person_id` of the incoming record to match the `person_id` of the potential match record. The data is also stored in the session.
2) "unlink" endpoint to update the `linked_status` to `False` when a user clicks on the "unlink" button. It also updates the `person_id` of the incoming record to `null`. The data is also stored in the session.

For the data that is stored in the cookie session, I'm not sure if it is better just to save the boolean value of the linked status (what I've done) or if all the data is better. It seems like the values tend to be short but I'm looking for feedback/best practices! 

## Related Issues
Closes #313 

## Additional Notes
I also removed the `max_age` of a cookie since we will be handling the reset in a follow up ticket. 
