### PR TITLE
Handle suffix during evaluation

### DIFF
--- a/src/recordlinker/linking/matchers.py
+++ b/src/recordlinker/linking/matchers.py
@@ -122,8 +122,8 @@ def compare_probabilistic_exact_match(
     :return: A tuple containing: a float of the score the feature comparison
       earned, and a boolean indicating whether one of the Fields was missing.
     """
-    incoming_record_fields = list(record.feature_iter(key))
-    mpi_record_fields = list(mpi_record.feature_iter(key))
+    incoming_record_fields = list(record.feature_iter(key, prepend_suffix=True))
+    mpi_record_fields = list(mpi_record.feature_iter(key, prepend_suffix=True))
     if len(incoming_record_fields) == 0 or len(mpi_record_fields) == 0:
         # Return early if a field is missing, and log that was the case
         return (missing_field_points_proportion * log_odds, True)
@@ -171,8 +171,8 @@ def compare_probabilistic_fuzzy_match(
     :return: A tuple containing: a float of the score the feature comparison
       earned, and a boolean indicating whether one of the Fields was missing.
     """
-    incoming_record_fields = list(record.feature_iter(key))
-    mpi_record_fields = list(mpi_record.feature_iter(key))
+    incoming_record_fields = list(record.feature_iter(key, prepend_suffix=True))
+    mpi_record_fields = list(mpi_record.feature_iter(key, prepend_suffix=True))
     if len(incoming_record_fields) == 0 or len(mpi_record_fields) == 0:
         # Return early if a field is missing, and log that was the case
         return (missing_field_points_proportion * log_odds, True)

--- a/tests/unit/linking/test_matchers.py
+++ b/tests/unit/linking/test_matchers.py
@@ -110,6 +110,38 @@ def test_compare_probabilistic_exact_match():
         missing_points_proportion,
     ) == (4.9, True)
 
+    # Suffix comparison cases
+    rec = schemas.PIIRecord(
+        name=[{"given": ["Joel"], "family": "Miller", "suffix": ["Senior"]}],
+    )
+    pat = models.Patient(
+        data={
+            "name": [{"given": ["Joel"], "family": "Miller"}],
+            "birthDate": "1970-06-07",
+        }
+    )
+    assert matchers.compare_probabilistic_exact_match(
+        rec,
+        schemas.PIIRecord.from_patient(pat),
+        schemas.Feature(attribute=schemas.FeatureAttribute.FIRST_NAME),
+        6.85,
+        missing_points_proportion,
+    ) == (0.0, False)
+
+    pat = models.Patient(
+        data={
+            "name": [{"given": ["Joel"], "family": "Miller", "suffix": ["Sr"]}],
+            "birthDate": "1970-06-07",
+        }
+    )
+    assert matchers.compare_probabilistic_exact_match(
+        rec,
+        schemas.PIIRecord.from_patient(pat),
+        schemas.Feature(attribute=schemas.FeatureAttribute.FIRST_NAME),
+        6.85,
+        missing_points_proportion,
+    ) == (6.85, False)
+
 
 def test_compare_probabilistic_fuzzy_match():
     missing_points_proportion = 0.5
@@ -180,3 +212,72 @@ def test_compare_probabilistic_fuzzy_match():
     )
     assert round(result[0], 3) == 2.0
     assert result[1]
+
+    # Test fuzzy comparisons with suffix
+    # Test 1: Same name, spelled correctly, one with suffix, other without
+    rec = schemas.PIIRecord(
+        name=[{"given": ["Joel"], "family": "Miller", "suffix": ["Senior"]}],
+    )
+    pat = models.Patient(
+        data={
+            "name": [{"given": ["Joel"], "family": "Miller"}],
+            "birthDate": "1970-06-07",
+        }
+    )
+    result = matchers.compare_probabilistic_fuzzy_match(
+        rec,
+        schemas.PIIRecord.from_patient(pat),
+        schemas.Feature(attribute=schemas.FeatureAttribute.FIRST_NAME),
+        6.85,
+        missing_points_proportion,
+    )
+    assert round(result[0], 3) == 6.089
+
+    # Test 2: Same name, spelled incorrectly, one with suffix, other without
+    pat = models.Patient(
+        data={
+            "name": [{"given": ["Jeol"], "family": "Miller"}],
+            "birthDate": "1970-06-07",
+        }
+    )
+    result = matchers.compare_probabilistic_fuzzy_match(
+        rec,
+        schemas.PIIRecord.from_patient(pat),
+        schemas.Feature(attribute=schemas.FeatureAttribute.FIRST_NAME),
+        6.85,
+        missing_points_proportion,
+    )
+    assert round(result[0], 3) == 5.137
+
+    # Test 3: Same name, spelled correctly, both with suffixes
+    pat = models.Patient(
+        data={
+            "name": [{"given": ["Joel"], "family": "Miller", "suffix": ["Sr"]}],
+            "birthDate": "1970-06-07",
+        }
+    )
+    result = matchers.compare_probabilistic_fuzzy_match(
+        rec,
+        schemas.PIIRecord.from_patient(pat),
+        schemas.Feature(attribute=schemas.FeatureAttribute.FIRST_NAME),
+        6.85,
+        missing_points_proportion,
+    )
+    assert round(result[0], 3) == 6.850
+
+    # Test 4: Different name, each with suffix
+    pat = models.Patient(
+        data={
+            "name": [{"given": ["Ellie"], "family": "Williams", "suffix": ["Jr"]}],
+            "birthDate": "2019-04-11",
+        }
+    )
+    result = matchers.compare_probabilistic_fuzzy_match(
+        rec,
+        schemas.PIIRecord.from_patient(pat),
+        schemas.Feature(attribute=schemas.FeatureAttribute.FIRST_NAME),
+        6.85,
+        missing_points_proportion,
+    )
+    assert round(result[0], 3) == 0.0
+    


### PR DESCRIPTION
## Description
This PR adds the final piece of handling suffixes during name evaluation. Previously, we used them only during blocking, but this change set now includes handling during evaluation as well. In order to still maintain the First_Name field as its own readable entity, we've simply re-used the `should-prepend` parameter in `feature_iter`. That way, it's only during the very specific cases we've outlined that we combine a name and a suffix.

## Related Issues
Closes #299 

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
