### PR TITLE
Integrate link unlink endpoints

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -36,6 +36,7 @@ services:
         - "8080:8080"
     environment:
       DB_URI: "postgresql+psycopg2://postgres:pw@db:5432/postgres"
+      SECRET_KEY: "not_a_good_secret_key"
       TEST_DB_URI: "sqlite:///:memory:"
       OTEL_TRACES_EXPORTER: "otlp"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://jaeger:4317"

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -14,7 +14,8 @@
         "focus-trap-react": "^11.0.3",
         "next": "15.2.4",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-toastify": "^11.0.5"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1260,6 +1261,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -3605,6 +3615,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
     },
     "node_modules/readdirp": {
       "version": "4.1.2",

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -18,7 +18,8 @@
     "focus-trap-react": "^11.0.3",
     "next": "15.2.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-toastify": "^11.0.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/ui/src/app/layout.tsx
+++ b/src/ui/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "../styles/index.scss";
 import Header from "@/components/header/header";
 import Footer from "@/components/footer/footer";
+import { ToastContainer } from "react-toastify";
 
 export const metadata: Metadata = {
   title: "Record Linker",
@@ -19,6 +20,7 @@ export default function RootLayout({
         <Header />
         <main>{children}</main>
         <Footer />
+        <ToastContainer position="bottom-left" />
       </body>
     </html>
   );

--- a/src/ui/src/app/match-queue/layout.tsx
+++ b/src/ui/src/app/match-queue/layout.tsx
@@ -1,6 +1,6 @@
 const MatchQueueLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
   return (
-    <div className="page-container--xl page-container--full-height padding-top-5 padding-bottom-10">
+    <div className="page-container page-container--xl page-container--full-height padding-top-5 padding-bottom-10">
       <h1 className="font-alt-xl margin-bottom-0">Record match queue</h1>
       <p className="subheading margin-bottom-4">
         Based on your algorithm configuration rules, Record Linker found no

--- a/src/ui/src/app/match-review/page.tsx
+++ b/src/ui/src/app/match-review/page.tsx
@@ -5,7 +5,7 @@ import RecordView from "./recordView";
 
 const MatchReview: React.FC = () => {
   return (
-    <div className="page-container--lg page-container--full-height padding-top-5 padding-bottom-10">
+    <div className="page-container page-container--lg page-container--full-height padding-top-5 padding-bottom-10">
       <BackToLink
         href={PAGES.RECORD_QUEUE}
         text="Return to record match queue"

--- a/src/ui/src/app/match-review/recordView.tsx
+++ b/src/ui/src/app/match-review/recordView.tsx
@@ -16,6 +16,7 @@ import RecordCompare, { FieldComparisonValues } from "./recordCompare";
 import { Patient } from "@/models/patient";
 import EmptyFallback from "@/components/emptyFallback/emptyFallback";
 import { AppError, PAGE_ERRORS } from "@/utils/errors";
+import { showToast, ToastType } from "@/components/toast/toast";
 
 function formatFieldValue(value: Patient[keyof Patient] | undefined): string {
   if (value instanceof Date) {
@@ -133,7 +134,15 @@ const RecordView: React.FC = () => {
           )}
         />
         <div className="margin-top-3">
-          <Button className="margin-right-105">
+          <Button
+            className="margin-right-105"
+            onClick={() =>
+              showToast(
+                ToastType.SUCCESS,
+                "The record has been reviewed and cleared from your queue.",
+              )
+            }
+          >
             Link record <LinkIcon size={3} />
           </Button>
           <Button>

--- a/src/ui/src/app/match-review/recordView.tsx
+++ b/src/ui/src/app/match-review/recordView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { useSearchParams, redirect } from "next/navigation";
 import RecordTable from "@/components/recordTable/recordTable";
 import { LinkIcon, LinkOffIcon } from "@/components/icons/icons";
 import { Button } from "@trussworks/react-uswds";
@@ -11,12 +11,17 @@ import {
   RecordMatch,
 } from "@/models/recordMatch";
 import ServerError from "@/components/serverError/serverError";
-import { getRecordMatch } from "@/data/matchReview";
+import {
+  getRecordMatch,
+  linkRecordAndMatch,
+  unlinkRecordAndMatch,
+} from "@/data/matchReview";
 import RecordCompare, { FieldComparisonValues } from "./recordCompare";
 import { Patient } from "@/models/patient";
 import EmptyFallback from "@/components/emptyFallback/emptyFallback";
 import { AppError, PAGE_ERRORS } from "@/utils/errors";
 import { showToast, ToastType } from "@/components/toast/toast";
+import { PAGES } from "@/utils/constants";
 
 function formatFieldValue(value: Patient[keyof Patient] | undefined): string {
   if (value instanceof Date) {
@@ -117,6 +122,47 @@ const RecordView: React.FC = () => {
   }, []);
 
   /**
+   * Event handlers
+   */
+  async function linkRecord() {
+    try {
+      await linkRecordAndMatch(recordId);
+
+      showToast(
+        ToastType.SUCCESS,
+        "The record has been reviewed and cleared from your queue.",
+      );
+    } catch (e) {
+      console.error(e);
+      showToast(
+        ToastType.ERROR,
+        "We were unable to process your request. Please try again.",
+      );
+    } finally {
+      redirect(PAGES.RECORD_QUEUE);
+    }
+  }
+
+  async function unlinkRecord() {
+    try {
+      await unlinkRecordAndMatch(recordId);
+
+      showToast(
+        ToastType.SUCCESS,
+        "The record has been reviewed and cleared from your queue.",
+      );
+    } catch (e) {
+      console.error(e);
+      showToast(
+        ToastType.ERROR,
+        "We were unable to process your request. Please try again.",
+      );
+    } finally {
+      redirect(PAGES.RECORD_QUEUE);
+    }
+  }
+
+  /**
    * HTML
    */
   if (pageError == PAGE_ERRORS.SERVER_ERROR) {
@@ -134,18 +180,10 @@ const RecordView: React.FC = () => {
           )}
         />
         <div className="margin-top-3">
-          <Button
-            className="margin-right-105"
-            onClick={() =>
-              showToast(
-                ToastType.SUCCESS,
-                "The record has been reviewed and cleared from your queue.",
-              )
-            }
-          >
+          <Button className="margin-right-105" onClick={linkRecord}>
             Link record <LinkIcon size={3} />
           </Button>
-          <Button>
+          <Button onClick={unlinkRecord}>
             Do not link record <LinkOffIcon size={3} />
           </Button>
         </div>

--- a/src/ui/src/app/page.tsx
+++ b/src/ui/src/app/page.tsx
@@ -15,6 +15,7 @@ const Home: React.FC = () => {
       <div className={style.hero}>
         <div
           className={classNames(
+            "page-container",
             "page-container--lg",
             "padding-y-10",
             "grid-row",
@@ -51,6 +52,7 @@ const Home: React.FC = () => {
       </div>
       <div
         className={classNames(
+          "page-container",
           "page-container--lg",
           "padding-top-7",
           "padding-x-6",
@@ -130,6 +132,7 @@ const Home: React.FC = () => {
       </div>
       <div
         className={classNames(
+          "page-container",
           "page-container--lg",
           "padding-top-4",
           "padding-bottom-6",

--- a/src/ui/src/components/serverError/serverError.module.scss
+++ b/src/ui/src/components/serverError/serverError.module.scss
@@ -2,13 +2,13 @@
 
 .serverError {
   background: $gray-cool-gray-cool-10;
-  border-radius: 0.25rem;
+  border-radius: $record-linker-border-radius;
   box-shadow: 0 0.25rem 0.5rem 0 rgba(0, 0, 0, 0.15);
   padding: 9.563rem 0;
 }
 
 .instructions {
-  border-radius: 0.25rem;
+  border-radius: $record-linker-border-radius;
   font-size: 1.125rem;
   border: solid 0.063rem $red-70;
   background: $gray-cool-gray-cool-2;

--- a/src/ui/src/components/toast/toast.tsx
+++ b/src/ui/src/components/toast/toast.tsx
@@ -1,0 +1,50 @@
+import { Alert } from "@trussworks/react-uswds";
+import { toast, ToastOptions } from "react-toastify";
+
+export enum ToastType {
+  SUCCESS = "success",
+  ERROR = "error",
+  WARNING = "warning",
+  INFO = "info",
+}
+
+const TOAST_AUTO_CLOSE_MS = 5000;
+
+interface CustomToastProps {
+  type: ToastType;
+  heading?: React.ReactNode;
+  content: React.ReactNode;
+}
+
+const CustomToast: React.FC<CustomToastProps> = ({
+  heading,
+  type,
+  content,
+}: CustomToastProps) => {
+  return (
+    <Alert
+      className="width-full radius-md margin-top-0 font-sans-md"
+      type={type}
+      heading={heading}
+      headingLevel={"h2"}
+    >
+      {content}
+    </Alert>
+  );
+};
+
+export function showToast(
+  type: ToastType,
+  content: React.ReactNode,
+  heading: React.ReactNode = undefined,
+  options?: ToastOptions<CustomToastProps>,
+) {
+  toast<CustomToastProps>(
+    <CustomToast type={type} content={content} heading={heading} />,
+    {
+      ...options,
+      type: type,
+      autoClose: TOAST_AUTO_CLOSE_MS,
+    },
+  );
+}

--- a/src/ui/src/data/matchReview.ts
+++ b/src/ui/src/data/matchReview.ts
@@ -42,6 +42,7 @@ export async function unlinkRecordAndMatch(
 ): Promise<RecordMatch> {
   const response = await fetch(`${API_URL}/demo/record/${id}/unlink`, {
     method: "POST",
+   credentials: "include",
   });
 
   if (response.ok) {

--- a/src/ui/src/data/matchReview.ts
+++ b/src/ui/src/data/matchReview.ts
@@ -23,6 +23,7 @@ export async function linkRecordAndMatch(
 ): Promise<RecordMatch> {
   const response = await fetch(`${API_URL}/demo/record/${id}/link`, {
     method: "POST",
+     credentials: "include",
   });
 
   if (response.ok) {

--- a/src/ui/src/data/matchReview.ts
+++ b/src/ui/src/data/matchReview.ts
@@ -17,3 +17,41 @@ export async function getRecordMatch(id: string | null): Promise<RecordMatch> {
     );
   }
 }
+
+export async function linkRecordAndMatch(
+  id: string | null,
+): Promise<RecordMatch> {
+  const response = await fetch(`${API_URL}/demo/record/${id}/link`, {
+    method: "POST",
+  });
+
+  if (response.ok) {
+    const serializedRecordMatch = await response.json();
+    return deserializeRecordMatch(serializedRecordMatch);
+  } else {
+    throw new AppError(
+      "linkRecordAndMatch",
+      "unsuccessful HTTP response",
+      response.status,
+    );
+  }
+}
+
+export async function unlinkRecordAndMatch(
+  id: string | null,
+): Promise<RecordMatch> {
+  const response = await fetch(`${API_URL}/demo/record/${id}/unlink`, {
+    method: "POST",
+  });
+
+  if (response.ok) {
+    const serializedRecordMatch = await response.json();
+    return deserializeRecordMatch(serializedRecordMatch);
+  } else {
+    throw new AppError(
+      "unlinkRecordAndMatch",
+      "unsuccessful HTTP response",
+      response.status,
+    );
+  }
+}

--- a/src/ui/src/styles/global.scss
+++ b/src/ui/src/styles/global.scss
@@ -4,14 +4,6 @@
 
 @use "variables" as *;
 
-:root {
-  /*toastify overrides*/
-  --toastify-toast-min-height: 30px;
-  --toastify-toast-bd-radius: 0.25rem;
-  --toastify-toast-padding: 0;
-  --toastify-toast-width: 550px;
-}
-
 * {
   box-sizing: border-box;
   padding: 0;

--- a/src/ui/src/styles/global.scss
+++ b/src/ui/src/styles/global.scss
@@ -82,7 +82,7 @@ th .descending-order {
     font-size: inherit;
   }
   .usa-alert__body {
-    border-radius: 0.25rem;
+    border-radius: $record-linker-border-radius;
     &::before {
       mask-size: 2rem 2rem;
     }

--- a/src/ui/src/styles/global.scss
+++ b/src/ui/src/styles/global.scss
@@ -4,6 +4,14 @@
 
 @use "variables" as *;
 
+:root {
+  /*toastify overrides*/
+  --toastify-toast-min-height: 30px;
+  --toastify-toast-bd-radius: 0.25rem;
+  --toastify-toast-padding: 0;
+  --toastify-toast-width: 550px;
+}
+
 * {
   box-sizing: border-box;
   padding: 0;
@@ -68,4 +76,25 @@ th .descending-order {
     position: relative;
     top: -0.188rem;
   }
+}
+
+/*
+ *  Toast
+ */
+
+.Toastify__toast-container {
+  .usa-alert__heading {
+    font-size: inherit;
+  }
+
+  .usa-alert__body {
+    border-radius: 0.25rem;
+    &::before {
+      mask-size: 2rem 2rem;
+    }
+  }
+}
+
+.Toastify__toast-icon {
+  display: none;
 }

--- a/src/ui/src/styles/global.scss
+++ b/src/ui/src/styles/global.scss
@@ -27,12 +27,10 @@ body {
   margin: 0 auto;
 
   &--lg {
-    @extend .page-container;
     max-width: 50rem;
   }
 
   &--xl {
-    @extend .page-container;
     max-width: 75rem;
   }
 
@@ -83,12 +81,26 @@ th .descending-order {
   .usa-alert__heading {
     font-size: inherit;
   }
-
   .usa-alert__body {
     border-radius: 0.25rem;
     &::before {
       mask-size: 2rem 2rem;
     }
+  }
+
+  // alert types
+  .usa-alert--success .usa-alert__body {
+    &::before {
+      background-color: $green-cool-vivid-80v;
+    }
+    color: $green-cool-vivid-80v;
+  }
+
+  .usa-alert--error .usa-alert__body {
+    &::before {
+      background-color: $red-cool-80v;
+    }
+    color: $red-cool-80v;
   }
 }
 

--- a/src/ui/src/styles/global.scss
+++ b/src/ui/src/styles/global.scss
@@ -9,6 +9,12 @@
   padding: 0;
   margin: 0;
   line-height: 140%;
+
+  // toastify
+  --toastify-toast-min-height: 2rem;
+  --toastify-toast-bd-radius: 0.25rem;
+  --toastify-toast-padding: 0;
+  --toastify-toast-width: 34rem;
 }
 
 body {
@@ -73,7 +79,6 @@ th .descending-order {
 /*
  *  Toast
  */
-
 .Toastify__toast-container {
   .usa-alert__heading {
     font-size: inherit;

--- a/src/ui/src/styles/uswds-customized.scss
+++ b/src/ui/src/styles/uswds-customized.scss
@@ -94,7 +94,7 @@ h5 {
 }
 
 .usa-table--record-linker {
-  border-radius: 0.25rem;
+  border-radius: $record-linker-border-radius;
   box-shadow: 0 0.25rem 0.5rem 0 rgba(0, 0, 0, 0.15);
   border-collapse: separate !important;
   background-color: transparent;

--- a/src/ui/src/styles/variables.scss
+++ b/src/ui/src/styles/variables.scss
@@ -9,6 +9,8 @@ $blue-cool-blue-cool-20: #adcfdc;
 $gray-cool-gray-cool-2: #f7f9fa;
 $gray-cool-gray-cool-20: #c6cace;
 $gray-cool-gray-cool-10: #dfe1e2;
+$green-cool-vivid-80v: #19311e;
+$red-cool-80v: #4f1c24;
 $red-70: #6f3331;
 $red-warm-60v: #9c3d10;
 $green-cool-40: #4d8055;

--- a/src/ui/src/styles/variables.scss
+++ b/src/ui/src/styles/variables.scss
@@ -22,3 +22,4 @@ $record-linker-header-footer-color: $blue-cool-blue-cool-80;
 $record-linker-heading-color: $blue-cool-blue-cool-80;
 $record-linker-subheading-color: $blue-cool-blue-cool-80;
 $record-linker-blue-border-light: #82b4c9;
+$record-linker-border-radius: 0.25rem;

--- a/src/ui/src/styles/variables.scss
+++ b/src/ui/src/styles/variables.scss
@@ -20,3 +20,11 @@ $record-linker-header-footer-color: $blue-cool-blue-cool-80;
 $record-linker-heading-color: $blue-cool-blue-cool-80;
 $record-linker-subheading-color: $blue-cool-blue-cool-80;
 $record-linker-blue-border-light: #82b4c9;
+
+//toastify overrides
+:root {
+  --toastify-toast-min-height: 2rem;
+  --toastify-toast-bd-radius: 0.25rem;
+  --toastify-toast-padding: 0;
+  --toastify-toast-width: 550px;
+}

--- a/src/ui/src/styles/variables.scss
+++ b/src/ui/src/styles/variables.scss
@@ -20,11 +20,3 @@ $record-linker-header-footer-color: $blue-cool-blue-cool-80;
 $record-linker-heading-color: $blue-cool-blue-cool-80;
 $record-linker-subheading-color: $blue-cool-blue-cool-80;
 $record-linker-blue-border-light: #82b4c9;
-
-//toastify overrides
-:root {
-  --toastify-toast-min-height: 2rem;
-  --toastify-toast-bd-radius: 0.25rem;
-  --toastify-toast-padding: 0;
-  --toastify-toast-width: 550px;
-}


### PR DESCRIPTION
## Description
This PR implements the link/unlink endpoints and the toast component. This work includes:
- Includes react-toastify dependency. Same library used in query connector.
- Integrates the toast component in the `root layout`.
- Implements a wrapper method to trigger the toast that takes care of the component customization with the uswds alert component.
- Clean up of the page-container classes. New implementation translates to less css lines after compilation.
- Adds styles in global for toastify classes.

## Related Issues
Implements #317 

## Additional Notes
<img width="758" alt="Screenshot 2025-05-05 at 1 15 27 PM" src="https://github.com/user-attachments/assets/32b8babc-3f49-404d-96fc-168fc9b0e2d7" />

