### PR TITLE
Added gzip compression middleware

### DIFF
--- a/src/api/recordlinker/main.py
+++ b/src/api/recordlinker/main.py
@@ -2,6 +2,7 @@ import os.path
 
 import fastapi
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import FileResponse
@@ -53,6 +54,8 @@ if settings.ui_host:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    app.add_middleware(GZipMiddleware, minimum_size=500, compresslevel=5)
 
 
 # FIXME: Change health check endpoint to /api/health


### PR DESCRIPTION
## Description
Static bundles should be served as gzip compressed assets whenever the browser accepts the format.

## Related Issues
None

## Additional Notes
I briefly looked into how gzip compression can be supported and the only thing I was able to find was on the fly. I anyone knows a better way to setup this in FastAPI is greatly appreciate it.
