### PR TITLE
Add feature medians

### DIFF
--- a/src/recordlinker/schemas/link.py
+++ b/src/recordlinker/schemas/link.py
@@ -65,6 +65,10 @@ class LinkResult(pydantic.BaseModel):
         description="The FHIR-corresponding Match-Grade assigned to the pass-specific "
         "score measured by this Result."
     )
+    median_features: dict = pydantic.Field(
+        description="A dictionary mapping string names for the Features used in evaluation "
+        "to the median log-odds points those features earned during linkage."
+    )
 
     @pydantic.model_validator(mode="before")
     @classmethod


### PR DESCRIPTION
## Description
This PR adds feature median scores to the LinkResult class for purposes of data reporting. The feature medians are stored in a dictionary on the LinkResult so they can be accessed by feature name by a user who wishes to see how much of the total log odds points for a match came from a particular feature. Testing has been updated where relevant to verify feature medians are accurately generated for non-matches, matches, and missing information.

## Related Issues
Closes #264 

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
