### PR TITLE
Fix bug in scripts/gen_seed_data.py

### DIFF
--- a/scripts/gen_seed_test_data.py
+++ b/scripts/gen_seed_test_data.py
@@ -75,7 +75,7 @@ def _generate_random_pii_record(faker):
                 use=random.choice(["home", "work", "mobile"]),
             )
         ],
-        race=random.choice(list(Race)),
+        race=str(random.choice(list(Race))),
         identifiers=list(_generate_random_identifiers(random.randint(1, 3), faker)),
     )
 

--- a/scripts/gen_seed_test_data.py
+++ b/scripts/gen_seed_test_data.py
@@ -75,7 +75,7 @@ def _generate_random_pii_record(faker):
                 use=random.choice(["home", "work", "mobile"]),
             )
         ],
-        race=str(random.choice(list(Race))),
+        race=[str(random.choice(list(Race)))],
         identifiers=list(_generate_random_identifiers(random.randint(1, 3), faker)),
     )
 


### PR DESCRIPTION
## Description
Somewhere in our updates to `PIIRecord`, we change the expectation for Race to a string. Faker produces a Race `object`, which I changed to a string so that we can continue to run `gen_seed_data.py`. 

Original error:
```
pii.py", line 411, in parse_race
    return [Race.parse(v) for v in value]
                                   ^^^^^
TypeError: 'Race' object is not iterable
```

## Related Issues
Fixes #359 

## Additional Notes
I'm guessing this script will be useful for jurisdictions testing out Record Linker so I wanted to make sure it stayed current.
