### PR TITLE
remove context from results in algorithm list

### DIFF
--- a/src/recordlinker/schemas/algorithm.py
+++ b/src/recordlinker/schemas/algorithm.py
@@ -291,6 +291,7 @@ class AlgorithmSummary(Algorithm):
     The schema for a summary of an algorithm record.
     """
 
+    algorithm_context: AlgorithmContext = pydantic.Field(exclude=True, default=AlgorithmContext())
     passes: typing.Sequence[AlgorithmPass] = pydantic.Field(exclude=True)
 
     # mypy doesn't support decorators on properties; https://github.com/python/mypy/issues/1362

--- a/tests/unit/routes/test_algorithm_router.py
+++ b/tests/unit/routes/test_algorithm_router.py
@@ -24,17 +24,6 @@ class TestListAlgorithms:
                 "label": "default",
                 "is_default": True,
                 "description": "First algorithm",
-                "algorithm_context": {
-                    "include_multiple_matches": True,
-                    "log_odds": [],
-                    "skip_values": [],
-                    "advanced": {
-                        "fuzzy_match_threshold": 0.9,
-                        "fuzzy_match_measure": "JaroWinkler",
-                        "max_missing_allowed_proportion": 0.5,
-                        "missing_field_points_proportion": 0.5,
-                    }
-                },
                 "pass_count": 0,
             },
         ]


### PR DESCRIPTION
## Description
The algorithm context was never meant to be in the results of the listing API call, this call is supposed to just give high level details of what algorithms are available.  The specific detail API endpoints for each algorithm, should be used to get info on the algorithm context and/or the passes.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
