### PR TITLE
Accept proxy headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ EXPOSE ${PORT}
 
 # Create an entrypoint script
 RUN echo '#!/bin/sh' > /code/entrypoint.sh && \
-    echo 'exec uvicorn recordlinker.main:app --app-dir src/api --host 0 --port "$PORT"' >> /code/entrypoint.sh && \
+    echo 'exec uvicorn recordlinker.main:app --proxy-headers --app-dir src/api --host 0 --port "$PORT"' >> /code/entrypoint.sh && \
     chmod +x /code/entrypoint.sh
 
 ENTRYPOINT ["/code/entrypoint.sh"]


### PR DESCRIPTION
## Summary
Add a flag to uvicorn to allow proxy headers, specifically X-Forwarded-For and X-Forwarded-Proto, from the upstream server.  This will allow for SSL termination to happen upstream and any info necessary for Record Linker to be preserved in request headers. Which is necessary when setting a secure session cookie.

## Additional Notes
[Proxies and forwarded headers](https://www.uvicorn.org/deployment/#proxies-and-forwarded-headers)

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
