### PR TITLE
bugfix: delete patient with keys

### DIFF
--- a/src/recordlinker/database/mpi_service.py
+++ b/src/recordlinker/database/mpi_service.py
@@ -461,6 +461,7 @@ def delete_patient(session: orm.Session, obj: models.Patient, commit: bool = Fal
     :param obj: The Patient to delete
     :param commit: Commit the transaction
     """
+    delete_blocking_values_for_patient(session, obj, commit=False)
     session.delete(obj)
     if commit:
         session.commit()

--- a/tests/unit/routes/test_patient_router.py
+++ b/tests/unit/routes/test_patient_router.py
@@ -125,7 +125,9 @@ class TestDeletePatient:
 
     def test_delete_patient(self, client):
         patient = models.Patient()
+        bv = models.BlockingValue(patient=patient, blockingkey=1, value="test")
         client.session.add(patient)
+        client.session.add(bv)
         client.session.flush()
 
         resp = client.delete(self.path(client, patient.reference_id))


### PR DESCRIPTION
## Description
Allow for deleting a Patient record that as BlockingValues.

## Additional Notes
No cascade deletes are being used, so when attempting to delete a Patient record that also has BlockingValues in the database, a SQL error is raised.  Explicitly deleting those BlockingValues first, allows the Patient to be deleted.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
