### PR TITLE
Add RMS boundary

### DIFF
--- a/src/recordlinker/tuning/prob_calc.py
+++ b/src/recordlinker/tuning/prob_calc.py
@@ -2,6 +2,8 @@ import math
 import typing
 
 from recordlinker.linking.matchers import compare_probabilistic_exact_match
+from recordlinker.linking.skip_values import remove_skip_values
+from recordlinker.schemas import algorithm as ag
 from recordlinker.schemas.pii import Feature
 from recordlinker.schemas.pii import FeatureAttribute
 from recordlinker.schemas.pii import PIIRecord
@@ -23,7 +25,7 @@ def calculate_class_probs(
     This function is used to calculate both the m- and u-probabilities,
     depending on the pair sample it is given.
 
-    :param true_match_pairs: A sequence of tuples containing pairs 
+    :param sampled_pairs: A sequence of tuples containing pairs 
       of patient data dictionaries.
     :returns: A dictionary mapping Feature names to their class
       probabilities.
@@ -69,3 +71,213 @@ def calculate_log_odds(
     for field in m_probs:
         log_odds[field] = math.log(m_probs[field] / u_probs[field])
     return log_odds
+
+
+def calculate_and_sort_tuning_scores(
+    true_match_pairs: typing.Sequence[typing.Tuple[dict, dict]],
+    non_match_pairs: typing.Sequence[typing.Tuple[dict, dict]],
+    log_odds: dict[str, float],
+    algorithm: ag.Algorithm
+) -> list[float]:
+    """
+    Given a set of true-matching pairs and a set of non-matching pairs
+    obtained from database sampling, calculates the pairwise RMS for
+    each collection and sorts the resulting scores. The evaluation
+    steps of the given algorithm are invoked on each pair of each class,
+    using the provided log-odds to compute RMS. Used for estimating
+    RMS possible match window boundaries and graphing distributions.
+
+    :param true_match_pairs: A sequence of tuples containing known
+      matching pairs of patient data dictionaries.
+    :param non_match_pairs: A sequence of tuples containing known non-
+      matching pairs of patient data dictionaries.
+    :param log_odds: A dictionary mapping Feature string names to their
+      computed log-odds values.
+    :param algorithm: A schema defining an algorithm to use for estimating
+      RMS threshold boundaries.
+    :returns: A tuple containing sorted lists of class RMS scores..
+    """
+    context: ag.AlgorithmContext = algorithm.algorithm_context
+
+    # Calculate the maximum number of log odds points for each pass at the top
+    # so we don't waste computations in the main loop below
+    max_points: dict[str, float] = {}
+    for idx, algorithm_pass in enumerate(algorithm.passes):
+        max_points_in_pass: float = sum(
+            [log_odds[str(e.feature)] or 0.0 for e in algorithm_pass.evaluators]
+        )
+        max_points[algorithm_pass.label or f"pass_{idx}"] = max_points_in_pass
+
+    true_match_scores: list[float] = _score_pairs_in_class(
+        true_match_pairs, log_odds, max_points, algorithm, context
+    )
+    non_match_scores: list[float] = _score_pairs_in_class(
+        non_match_pairs, log_odds, max_points, algorithm, context
+    )
+    true_match_scores = sorted(true_match_scores)
+    non_match_scores = sorted(non_match_scores)
+    return (true_match_scores, non_match_scores)
+
+
+def estimate_rms_bounds(
+    true_match_scores: list[float],
+    non_match_scores: list[float],
+) -> typing.Tuple[float, float]:
+    """
+    Identifies suggested boundaries for the RMS possible match window
+    using previously sampled pairs of true and non matches. 
+
+    :param true_match_pairs: A sequence of tuples containing known
+      matching pairs of patient data dictionaries.
+    :param non_match_pairs: A sequence of tuples containing known non-
+      matching pairs of patient data dictionaries.
+    :returns: A tuple containing the Minimum Match Threshold and the Certain
+      Match Threshold suggested by the input data.
+    """
+    # Overlap the lists to find the possible match window:
+    # MMT is first non-match score greater than smallest true-match score
+    # CMT is first true-match score greater than all non-match scores
+    mmt = None
+    cmt = None
+    for t in non_match_scores:
+        if t >= true_match_scores[0]:
+            mmt = t
+            break
+    for t in true_match_scores:
+        if t > non_match_scores[-1]:
+            cmt = t
+            break
+
+    # To account for unseen data, buffer each threshold by pushing it 
+    # towards its respective distribution's extreme
+    if mmt is not None:
+        mmt = max([0, mmt - 0.025])
+    if cmt is not None:
+        cmt = min([1.0, cmt + 0.025])
+    
+    # Edge Case 1: Distributions are totally disjoint
+    # MMT can just be set to the highest non-match score
+    if mmt is None:
+        mmt = non_match_scores[-1]
+
+    # Edge Case 2: No true match score larger than largest non-match
+    # This is EXTREMELY unnatural and can only happen if either the
+    # distributions are inverted (true match scores left of non-match
+    # scores) or the true-match curve is a subset contained entirely 
+    # within the non-match curve--in either case, the problem is likely
+    # the data and not the scoring procedure
+    if cmt is None:
+        # Best we can do is set the CMT to be beyond the range of the
+        # non-match curve
+        cmt = min([non_match_scores[-1] + 0.01, 1.0])
+    
+    return (mmt, cmt)
+
+
+def _compare_records_in_pair(
+    record_1: PIIRecord,
+    record_2: PIIRecord,
+    log_odds: dict[str, float],
+    max_log_odds_points: float,
+    algorithm_pass: ag.AlgorithmPass,
+    context: ag.AlgorithmContext,
+) -> float:
+    """
+    Helper function to perform a feature-wise comparison against two records
+    in a tuning pair. This function is similar to the `compare` function used
+    in linking.py, except that log_odds weights and the log_odds_maximum are
+    manually provided, and feature-wise individual contributions are not
+    tracked separately.
+
+    :param record_1: The first patient record in a pair.
+    :param record_2: The second patient record in a pair.
+    :param log_odds: A dictionary mapping Feature string names to their
+      calculated log-odds values.
+    :param max_log_odds_points: The maximum number of log-odds points that can
+      be scored in the pass of the algorithm in which the records are being
+      compared.
+    :param algorithm_pass: The schema for the algorithm pass in which the 
+      records are being compared.
+    :param context: The schema for the algorithm context being used.
+    :returns: The number of log-odds points earned by the comparison between
+      the two records.
+    """
+    missing_field_weights: float = 0.0
+    results: list[float] = []
+    max_missing_proportion: float = context.advanced.max_missing_allowed_proportion
+    for evaluator in algorithm_pass.evaluators:
+        log_odds_for_field: float = log_odds[str(evaluator.feature)] or 0.0
+        # Evaluate the comparison function, track missingness, and append the
+        # score component to the list
+        fn: typing.Callable = evaluator.func.callable()
+        kwargs = {
+            "log_odds": log_odds_for_field,
+            "missing_field_points_proportion": context.advanced.missing_field_points_proportion,
+            "fuzzy_match_threshold": evaluator.fuzzy_match_threshold
+            or context.advanced.fuzzy_match_threshold,
+            "fuzzy_match_measure": evaluator.fuzzy_match_measure
+            or context.advanced.fuzzy_match_measure,
+        }
+        result: tuple[float, bool] = fn(record_1, record_2, evaluator.feature, **kwargs)
+        if result[1]:
+            # The field was missing, so update the running tally of how much
+            # the candidate is missing overall
+            missing_field_weights += log_odds
+        results.append(result[0])
+
+    # Make sure this score wasn't just accumulated with missing checks
+    if missing_field_weights <= (max_missing_proportion * max_log_odds_points):
+        rule_result = sum(results)
+    else:
+        rule_result = 0.0
+    return rule_result
+
+
+def _score_pairs_in_class(
+        class_sample: typing.Sequence[typing.Tuple[dict, dict]],
+        log_odds: dict[str, float],
+        max_points: dict[str, float],
+        algorithm: ag.Algorithm,
+        context: ag.AlgorithmContext,
+    ) -> list[float]:
+    """
+    Given a sample of class-partitioned data and a record linkage algorithm,
+    compute the RMS of each pair in the class sample, taking the best RMS
+    the pair could have scored across all passes of the provided algorithm.
+
+    :param class_sample: A sequence of tuples of pairs of patient data
+      dictionaries, each belonging to the same class of tuning data (either
+      known true-match or known non-match).
+    :param log_odds: A dictionary mapping Feature string names to their 
+      calculated log-odds values.
+    :param max_points: A dictionary mapping the name of each pass of an 
+      algorithm to the maximum possible number of log-odds points obtainable
+      in that pass.
+    :param algorithm: The schema for an algorithm to use for comparing the
+      record pairs.
+    :param context: The schema for an algorithm context to use.
+    :returns: A list of RMS values, one for each input pair.
+    """
+    class_scores: list[float] = []
+    for pair in class_sample:
+        pii_record_1 = PIIRecord.from_data(pair[0])
+        pii_record_1 = remove_skip_values(pii_record_1, context.skip_values)
+        pii_record_2 = PIIRecord.from_data(pair[1])
+        pii_record_2 = remove_skip_values(pii_record_2, context.skip_values)
+
+        # We need to find the best RMS across all passes that this pair
+        # could achieve
+        scores_across_passes = []
+        for idx, algorithm_pass in enumerate(algorithm.passes):
+            max_points_in_pass = max_points[algorithm_pass.label or f"pass_{idx}"]
+            score_in_pass = _compare_records_in_pair(
+                pii_record_1,
+                pii_record_2,
+                log_odds,
+                max_points_in_pass,
+                algorithm_pass,
+                context
+            )
+            scores_across_passes.append(score_in_pass / max_points_in_pass)
+        class_scores.append(max(scores_across_passes))
+    return class_scores

--- a/tests/unit/tuning/test_prob_calc.py
+++ b/tests/unit/tuning/test_prob_calc.py
@@ -1,7 +1,14 @@
+import pytest
 from conftest import load_test_json_asset
 
+from recordlinker.linking.skip_values import remove_skip_values
+from recordlinker.schemas.pii import PIIRecord
+from recordlinker.tuning.prob_calc import _compare_records_in_pair
+from recordlinker.tuning.prob_calc import _score_pairs_in_class
+from recordlinker.tuning.prob_calc import calculate_and_sort_tuning_scores
 from recordlinker.tuning.prob_calc import calculate_class_probs
 from recordlinker.tuning.prob_calc import calculate_log_odds
+from recordlinker.tuning.prob_calc import estimate_rms_bounds
 
 
 class TestTuningProbabilityCalculators:
@@ -110,3 +117,119 @@ class TestTuningProbabilityCalculators:
         assert round(log_odds['EMAIL'], 3) == 0.0
         assert round(log_odds['COUNTY'], 3) == 1.792
         assert round(log_odds['IDENTIFIER'], 3) == 1.792
+
+
+class TestScoreTuningSamples:
+    @pytest.fixture
+    def log_odds(self):
+        return {
+            'BIRTHDATE': 1.386,
+            'SEX': 0.916,
+            'FIRST_NAME': 1.609,
+            'LAST_NAME': 1.792,
+            'ADDRESS': 1.792,
+            'CITY': 1.386,
+            'STATE': 1.099,
+            'ZIP': 1.609,
+            'RACE': 1.099,
+            'TELECOM': 1.792,
+            'PHONE': 1.792,
+            'EMAIL': 0.0,
+            'COUNTY': 1.792,
+            'IDENTIFIER': 1.792,
+        }
+    
+    @pytest.fixture
+    def true_match_samples(self):
+        test_pairs = load_test_json_asset("synthetic_tuning_pairs.json")
+        rows = []
+        for p in test_pairs["samples"]:
+            row = (p["data_1"], p["data_2"])
+            rows.append(row)
+        return rows
+    
+    @pytest.fixture
+    def non_match_samples(self):
+        test_pairs = load_test_json_asset("synthetic_tuning_pairs.json")
+        rows = []
+        for i in range(len(test_pairs["samples"]) - 1):
+            r1 = test_pairs["samples"][i]["data_1"]
+            r2 = test_pairs["samples"][i+1]["data_2"]
+            rows.append((r1, r2))
+        rows.append((
+            test_pairs["samples"][len(test_pairs["samples"]) - 1]["data_1"],
+            test_pairs["samples"][0]["data_2"]
+        ))
+        return rows
+
+    def test_compare_records_in_pair(self, default_algorithm, log_odds, true_match_samples, non_match_samples):
+
+        context = default_algorithm.algorithm_context
+        pass_1 = default_algorithm.passes[0]
+        max_points = sum(
+            [log_odds[str(e.feature)] or 0.0 for e in pass_1.evaluators]
+        )
+
+        # Run one check of comparisons on a true match pair
+        # Fields should all line up, should be max
+        pii_record_1 = PIIRecord.from_data(true_match_samples[0][0])
+        pii_record_1 = remove_skip_values(pii_record_1, context.skip_values)
+        pii_record_2 = PIIRecord.from_data(true_match_samples[0][1])
+        pii_record_2 = remove_skip_values(pii_record_2, context.skip_values)
+        result = _compare_records_in_pair(pii_record_1, pii_record_2, log_odds, max_points, pass_1, context)
+        assert result == 3.401
+
+        # Now run a check of comparisons on a non-match pair
+        # Stuff should be missing and wrong so we should get a 0
+        pii_record_1 = PIIRecord.from_data(non_match_samples[0][0])
+        pii_record_1 = remove_skip_values(pii_record_1, context.skip_values)
+        pii_record_2 = PIIRecord.from_data(non_match_samples[0][1])
+        pii_record_2 = remove_skip_values(pii_record_2, context.skip_values)
+        result = _compare_records_in_pair(pii_record_1, pii_record_2, log_odds, max_points, pass_1, context)
+        assert result == 0.0
+
+    def test_score_pairs_in_class(self, default_algorithm, log_odds, true_match_samples, non_match_samples):
+        context = default_algorithm.algorithm_context
+        max_points: dict[str, float] = {}
+        for idx, algorithm_pass in enumerate(default_algorithm.passes):
+            max_points_in_pass: float = sum(
+                [log_odds[str(e.feature)] or 0.0 for e in algorithm_pass.evaluators]
+            )
+            max_points[algorithm_pass.label or f"pass_{idx}"] = max_points_in_pass
+        
+        true_scores = _score_pairs_in_class(true_match_samples, log_odds, max_points, default_algorithm, context)
+        # 4th element has non-pretty number, check it on its own first and
+        # then just remove it from the list to check the rest
+        assert round(true_scores[3], 3) == 0.564
+        del true_scores[3]
+        assert true_scores == [1.0, 1.0, 1.0, 1.0]
+        non_match_scores = _score_pairs_in_class(non_match_samples, log_odds, max_points, default_algorithm, context)
+        assert non_match_scores == [0.0, 0.0, 0.0, 0.0, 0.0]
+    
+    def test_calculate_and_sort_tuning_scores(self, default_algorithm, log_odds, true_match_samples, non_match_samples):
+        true_match_scores, non_match_scores = calculate_and_sort_tuning_scores(true_match_samples, non_match_samples, log_odds, default_algorithm)
+        assert non_match_scores == [0.0, 0.0, 0.0, 0.0, 0.0]
+        assert round(true_match_scores[0], 3) == 0.564
+        assert true_match_scores[1:] == [1.0, 1.0, 1.0, 1.0]
+
+class TestRmsBoundEstimation:
+    def test_estimate_rms_no_overlap_no_mmt(self):
+        true_match_scores = [0.564, 1.0, 1.0, 1.0, 1.0]
+        non_match_scores = [0.0, 0.0, 0.0, 0.05, 0.25]
+        mmt, cmt = estimate_rms_bounds(true_match_scores, non_match_scores)
+        assert mmt == 0.25
+        assert cmt == 0.589
+
+    def test_estimate_rms_normal_overlap(self):
+        true_match_scores = [0.85, 0.92, 0.97, 1.0, 1.0]
+        non_match_scores = [0.0, 0.15, 0.33, 0.86, 0.93]
+        mmt, cmt = estimate_rms_bounds(true_match_scores, non_match_scores)
+        assert mmt == 0.835
+        assert cmt == 0.995
+
+    def test_estimate_rms_skewed_overlap_no_cmt(self):
+        true_match_scores = [0.77, 0.78, 0.78, 0.79, 0.81]
+        non_match_scores = [0.56, 0.64, 0.67, 0.8, 0.83]
+        mmt, cmt = estimate_rms_bounds(true_match_scores, non_match_scores)
+        assert mmt == 0.775
+        assert cmt == 0.84


### PR DESCRIPTION
## Description
This PR adds functionality for scoring each of the class-partitioned pairs of patient records from the DB, and then using those scores to estimate reasonable bounds for the possible match window (MMT and CMT). Numerous helper functions got added to tuning to allow us to perform a modified version of RL's evaluation step (no blocking needed because the records are already in pairs) with us providing manual overrides to a number of parameters (namely log-odds).

## Related Issues
Closes #446 

## Additional Notes
As usual, I set up the local server to add this processing step to hitting the dummy tuning endpoint, and end to end, the entire computation was ~90 seconds. So that means DB sampling and log-odds calculating is 60-70s and scoring and sorting the class lists takes about 20s.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
