### PR TITLE
make alembic pyproject.toml lookup dynamic

### DIFF
--- a/src/recordlinker/utils/path.py
+++ b/src/recordlinker/utils/path.py
@@ -1,10 +1,11 @@
 import json
+import os.path
 import pathlib
 
 
-def project_root() -> pathlib.Path:
+def code_root() -> pathlib.Path:
     """
-    Returns the path to the project root directory.
+    Returns the root directory of the recordlinker source code.
     """
     root = pathlib.Path(__file__).resolve()
     while root.name != "recordlinker":
@@ -14,12 +15,31 @@ def project_root() -> pathlib.Path:
     return root
 
 
+def repo_root(start: pathlib.Path | None = None) -> pathlib.Path | None:
+    """
+    Returns the root directory of the recordlinker repository, or None if not found.
+    """
+    start = start or pathlib.Path(__file__).resolve()
+    for directory in [start] + list(start.parents):
+        if (directory / "pyproject.toml").is_file():
+            return directory
+    return None
+
+
+def rel_path(path: pathlib.Path) -> str:
+    """
+    Return a path relative to the CWD of the given path.
+    """
+    cwd: pathlib.Path = pathlib.Path.cwd()
+    return str(os.path.relpath(path, cwd))
+
+
 def read_json(path: str) -> dict:
     """
     Loads a JSON file.
     """
     if not pathlib.Path(path).is_absolute():
         # if path is relative, append to the project root
-        path = str(pathlib.Path(project_root(), path))
+        path = str(pathlib.Path(code_root(), path))
     with open(path, "r") as fobj:
         return json.load(fobj)

--- a/tests/unit/utils/test_path.py
+++ b/tests/unit/utils/test_path.py
@@ -7,20 +7,35 @@ import pytest
 from recordlinker.utils import path as utils
 
 
-def test_project_root():
-    root = utils.project_root()
+def test_code_root():
+    root = utils.code_root()
     assert root.name == "recordlinker"
 
 
-def test_project_root_not_found():
+def test_code_root_not_found():
     with unittest.mock.patch("pathlib.Path.resolve") as mock_resolve:
         mock_resolve.return_value = pathlib.Path("/")
         with pytest.raises(FileNotFoundError):
-            utils.project_root()
+            utils.code_root()
+
+def test_repo_root():
+    root = utils.repo_root()
+    assert root is not None
+
+
+def test_repo_root_not_found():
+    with unittest.mock.patch("pathlib.Path.resolve") as mock_resolve:
+        mock_resolve.return_value = pathlib.Path("/")
+        root = utils.repo_root()
+        assert root is None
+
+
+def test_rel_path():
+    assert utils.rel_path(utils.code_root()).endswith("src/recordlinker")
 
 
 def test_read_json_relative():
-    tmp = utils.project_root() / "test.json"
+    tmp = utils.code_root() / "test.json"
     with open(tmp, "w") as fobj:
         fobj.write('{"key": "value"}')
     assert utils.read_json("test.json") == {"key": "value"}


### PR DESCRIPTION
## Description
Dynamically set the pyproject.toml file path for alembic based on the CWD.  This allows us to run the alembic migration code even if we are not running python in the repo root directory.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [ ] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [ ] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added or updated test cases to cover my changes, if applicable.
- [ ] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
