### PR TITLE
proc calc with iterators

### DIFF
--- a/src/recordlinker/database/mpi_service.py
+++ b/src/recordlinker/database/mpi_service.py
@@ -5,12 +5,14 @@ recordlinker.linking.mpi_service
 This module provides the data access functions to the MPI tables
 """
 
+import itertools
 import logging
 import math
 import random
 import typing
 import uuid
 
+from sqlalchemy import bindparam
 from sqlalchemy import exists
 from sqlalchemy import insert
 from sqlalchemy import literal
@@ -24,7 +26,6 @@ from recordlinker import schemas
 from . import get_random_function
 
 LOGGER = logging.getLogger(__name__)
-
 
 
 class BlockData:
@@ -547,65 +548,50 @@ def get_orphaned_persons(
 
 
 def generate_true_match_tuning_samples(
-        session: orm.Session,
-        n_pairs: int
-    ) -> typing.Sequence[typing.Tuple[dict, dict]]:
+    session: orm.Session, n_pairs: int
+) -> typing.Iterator[typing.Tuple[dict, dict]]:
     """
-    Creates a sample of known "true match" pairs of patient records of 
-    size n_pairs using previously labeled data. Pairs of records are 
+    Creates a sample of known "true match" pairs of patient records of
+    size n_pairs using previously labeled data. Pairs of records are
     randomly sampled from randomly chosen person clusters until
     a list of unique pairs has been obtained.
 
     :param session: A database session to use for executing queries.
     :param n_pairs: The number of pairs of true-matches to generate.
-    :returns A list of tuples containing pairs of patient data 
+    :returns An iterator of tuples containing pairs of patient data
       dictionaries.
     """
     p1 = orm.aliased(models.Patient, name="p1")
     p2 = orm.aliased(models.Patient, name="p2")
     random_pairs = (
-        expression.select(
-            p1.id.label("patient_1_id"),
-            p2.id.label("patient_2_id")
-        ).join_from(
+        expression.select(p1.id.label("patient_1_id"), p2.id.label("patient_2_id"))
+        .join_from(
             p1,
             p2,
-            expression.and_(
-                p1.person_id == p2.person_id,
-                p1.id < p2.id,
-                p1.person_id.isnot(None)
-            )
-        ).order_by(
-            get_random_function(session.get_bind().dialect)
-        ).limit(
-            n_pairs
-        ).cte()
+            expression.and_(p1.person_id == p2.person_id, p1.id < p2.id, p1.person_id.isnot(None)),
+        )
+        .order_by(get_random_function(session.get_bind().dialect))
+        .limit(n_pairs)
+        .cte()
     )
     sample = (
         expression.select(
-            p1.person_id,
-            random_pairs.c.patient_1_id,
-            random_pairs.c.patient_2_id,
             p1.data.label("patient_data_1"),
-            p2.data.label("patient_data_2")
-        ).join_from(
-            random_pairs, p1, p1.id == random_pairs.c.patient_1_id
-        ).join(
-            p2, p2.id == random_pairs.c.patient_2_id
+            p2.data.label("patient_data_2"),
         )
+        .join_from(random_pairs, p1, p1.id == random_pairs.c.patient_1_id)
+        .join(p2, p2.id == random_pairs.c.patient_2_id)
     )
 
-    db_rows = session.execute(sample).all()
-    return [(row[3], row[4]) for row in db_rows]
+    for row in session.execute(sample):
+        yield (row[0], row[1])
 
 
 def generate_non_match_tuning_samples(
-        session: orm.Session,
-        sample_size: int,
-        n_pairs: int
-    ) -> typing.Tuple[typing.Sequence[typing.Tuple[dict, dict]], int]:
+    session: orm.Session, sample_size: int, n_pairs: int
+) -> typing.Iterator[typing.Tuple[typing.Tuple[dict, dict], int]]:
     """
-    Creates a sample of known "non match" pairs of patient records of 
+    Creates a sample of known "non match" pairs of patient records of
     size n_pairs using previously labeled data. The complete collection
     of patient data is first randomly sub-sampled if there are more than
     100k patient rows (since a random sample from a random sample is
@@ -615,21 +601,21 @@ def generate_non_match_tuning_samples(
     :param session: A database session with which to execute queries.
     :param sample_size: The number of patient records to sub-sample from
       the MPI for use with combinatorial pairing. Effectively "shrinks"
-      the scope of the world the function needs to consider, since 
+      the scope of the world the function needs to consider, since
       randomly sampling out of a random sample is equivalent to randomly
       sampling from the initial population.
     :param n_pairs: The number of non-matching pairs to try to generate.
-      The function's internal pairing loop (which performs random 
-      generation and checking) is bounded by a secondary stopping 
+      The function's internal pairing loop (which performs random
+      generation and checking) is bounded by a secondary stopping
       condition which may terminate before this number is hit (in order
       to prevent excessive time spent looping).
-    :returns: A tuple whose first element is a sequence of randomly 
+    :returns: An iterator tuple whose first element is a sequence of randomly
       sub-sampled pairs of non-matching records, and whose second element
       is the length of the sub-sample actually retrieved from the DB
       from which these pairs were generated.
     """
     # First, sanity check that we have a big enough sample size to grab
-    # the requested number of pairs in "reasonable" time--use the 
+    # the requested number of pairs in "reasonable" time--use the
     # Taylor approximation for e^x derived from the Birthday Problem
     if sample_size == 1:
         raise ValueError("Cannot sample from a single database point")
@@ -640,48 +626,43 @@ def generate_non_match_tuning_samples(
     if repeat_probability >= 0.5:
         raise ValueError("Too many pairs requested for sample size")
 
-    # Start with a large sub-sample from which we'll draw pairs
-    query = expression.select(
-        models.Patient.id,
-        models.Patient.person_id,
-        models.Patient.data
-    ).where(
-        ~models.Patient.person_id.is_(None)
-    ).order_by(
-        get_random_function(session.get_bind().dialect)
-    ).limit(
-        sample_size
+    random_ids: list[int] = [
+        row[0]
+        for row in session.query(models.Patient.id)
+        .order_by(get_random_function(session.get_bind().dialect))
+        .limit(sample_size)
+        .all()
+    ]
+    query: expression.Select = (
+        select(models.Patient.id, models.Patient.person_id, models.Patient.data)
+        .where(models.Patient.id.in_(bindparam("ids")))
     )
-    sample = list(session.execute(query).all())
 
-    # Now, combinatorially build up the negative pairs by
-    # randomly selecting two records, making sure they don't
-    # match, and then storing them as a pair
-    already_seen = set()
-    neg_pairs: list[tuple] = []
-    # Alternate stopping condition to prevent us from looping forever
-    num_iters = 0
-    max_iters = 10 * n_pairs
-    while len(neg_pairs) < n_pairs and num_iters < max_iters:
-        num_iters += 1
-        idx_1 = random.randint(0, len(sample) - 1)
-        idx_2 = random.randint(0, len(sample) - 1)
+    already_seen: set[tuple[int, int]] = set()
+    num_iters: int = 0
+    num_pairs: int = 0
+    found_size: int = len(random_ids)
+    while True:
+        ids: list[int] = random.choices(random_ids, k=100)
+        for pair_1, pair_2 in itertools.pairwise(session.execute(query, {"ids": ids})):
+            # iterate over the query, pulling out the first two items at a time
+            if num_iters > 10 * n_pairs:
+                LOGGER.warn("too many non-match iterations", extra={"n_pairs": n_pairs})
+                return
+            if num_pairs >= n_pairs:
+                # end case, we have enough pairs
+                return
 
-        # Can't make a record pair from one record
-        if idx_1 != idx_2:
+            num_iters += 2
+            seen: tuple[int, int] = tuple(sorted((pair_1[0], pair_2[0])))
 
-            # We'll use the convention of making the "smaller" ID the
-            # first index, easier for set tracking
-            if sample[idx_1][0] < sample[idx_2][0]:
-                record_row_1 = sample[idx_1]
-                record_row_2 = sample[idx_2]
-            else:
-                record_row_1 = sample[idx_2]
-                record_row_2 = sample[idx_1]                
+            if pair_1[1] is None or pair_2[1] is None:
+                continue  # no person
+            if pair_1[1] == pair_2[1]:
+                continue  # same person
+            if seen in already_seen:
+                continue  # already seen
 
-            # If the person_ids don't agree, this is a valid neg pair
-            if record_row_1[1] != record_row_2[1]:
-                if (record_row_1[0], record_row_2[0]) not in already_seen:
-                    already_seen.add((record_row_1[0], record_row_2[0]))
-                    neg_pairs.append((record_row_1[2], record_row_2[2]))
-    return neg_pairs, len(sample)
+            already_seen.add(seen)
+            num_pairs += 1
+            yield (pair_1[2], pair_2[2]), found_size

--- a/src/recordlinker/database/mpi_service.py
+++ b/src/recordlinker/database/mpi_service.py
@@ -644,8 +644,8 @@ def generate_non_match_tuning_samples(
     found_size: int = len(random_ids)
     while True:
         ids: list[int] = random.choices(random_ids, k=100)
+        # iterate over the query, pulling out the first two items at a time
         for pair_1, pair_2 in itertools.pairwise(session.execute(query, {"ids": ids})):
-            # iterate over the query, pulling out the first two items at a time
             if num_iters > 10 * n_pairs:
                 LOGGER.warn("too many non-match iterations", extra={"n_pairs": n_pairs})
                 return
@@ -653,7 +653,7 @@ def generate_non_match_tuning_samples(
                 # end case, we have enough pairs
                 return
 
-            num_iters += 2
+            num_iters += 1
             seen: tuple[int, int] = tuple(sorted((pair_1[0], pair_2[0])))
 
             if pair_1[1] is None or pair_2[1] is None:

--- a/src/recordlinker/schemas/__init__.py
+++ b/src/recordlinker/schemas/__init__.py
@@ -28,7 +28,6 @@ from .mpi import PersonRefs
 from .pii import Feature
 from .pii import FeatureAttribute
 from .pii import PIIRecord
-from .pii import TuningPair
 from .seed import Cluster
 from .seed import ClusterGroup
 from .seed import PersonCluster
@@ -36,7 +35,9 @@ from .seed import PersonGroup
 from .tuning import PassRecommendation
 from .tuning import TuningJob
 from .tuning import TuningJobResponse
+from .tuning import TuningPair
 from .tuning import TuningParams
+from .tuning import TuningProbabilities
 from .tuning import TuningResults
 
 __all__ = [
@@ -80,4 +81,5 @@ __all__ = [
     "TuningJobResponse",
     "PassRecommendation",
     "TuningPair",
+    "TuningProbabilities",
 ]

--- a/src/recordlinker/schemas/__init__.py
+++ b/src/recordlinker/schemas/__init__.py
@@ -28,6 +28,7 @@ from .mpi import PersonRefs
 from .pii import Feature
 from .pii import FeatureAttribute
 from .pii import PIIRecord
+from .pii import TuningPair
 from .seed import Cluster
 from .seed import ClusterGroup
 from .seed import PersonCluster
@@ -78,4 +79,5 @@ __all__ = [
     "TuningJob",
     "TuningJobResponse",
     "PassRecommendation",
+    "TuningPair",
 ]

--- a/src/recordlinker/schemas/pii.py
+++ b/src/recordlinker/schemas/pii.py
@@ -71,7 +71,7 @@ class Feature(StrippedBaseModel):
     The schema for a feature.
     """
 
-    model_config = pydantic.ConfigDict(extra="allow")
+    model_config = pydantic.ConfigDict(extra="allow", frozen=True)
 
     suffix: typing.Optional[IdentifierType] = None
     attribute: FeatureAttribute
@@ -630,24 +630,3 @@ class PIIRecord(StrippedBaseModel):
             # a PII data dict could have multiple given names
             for val in self.blocking_keys(key):
                 yield key, val
-
-
-class TuningPair(pydantic.BaseModel):
-    """
-    A pair of PIIRecords that are used for training a model.
-    """
-
-    record1: PIIRecord
-    record2: PIIRecord
-    sample_used: typing.Optional[int] = None
-
-    @classmethod
-    def from_data(cls, record1: dict, record2: dict, sample_used: int | None = None) -> typing.Self:
-        """
-        Contruct a TuningPair from raw PII data dictionaries.
-        """
-        return cls.model_construct(
-            record1=PIIRecord.from_data(record1),
-            record2=PIIRecord.from_data(record2),
-            sample_used=sample_used,
-        )

--- a/src/recordlinker/schemas/pii.py
+++ b/src/recordlinker/schemas/pii.py
@@ -236,42 +236,31 @@ class Address(StrippedBaseModel):
     )
     model_config = pydantic.ConfigDict(extra="allow")
 
-    line: typing.List[str] = pydantic.Field(default_factory=list,
+    line: typing.List[str] = pydantic.Field(
+        default_factory=list,
         description=(
             "A list of street name, number, direction & P.O. Box etc., "
             "the order in which lines should appear in an address label."
-        )
+        ),
     )
-    city: typing.Optional[str] = pydantic.Field(
-        default=None,
-        description="Name of city, town etc."
-    )
+    city: typing.Optional[str] = pydantic.Field(default=None, description="Name of city, town etc.")
     state: typing.Optional[str] = pydantic.Field(
-        default=None,
-        description="US State or abbreviation"
+        default=None, description="US State or abbreviation"
     )
     postal_code: typing.Optional[str] = pydantic.Field(
         default=None,
         validation_alias=pydantic.AliasChoices(
             "postal_code", "postalcode", "postalCode", "zip_code", "zipcode", "zipCode", "zip"
         ),
-        description="Postal code for area"
+        description="Postal code for area",
     )
-    county: typing.Optional[str] = pydantic.Field(
-        default=None,
-        description="Name of county"
-    )
-    country: typing.Optional[str] = pydantic.Field(
-        default=None,
-        description="Name of country"
-    )
+    county: typing.Optional[str] = pydantic.Field(default=None, description="Name of county")
+    country: typing.Optional[str] = pydantic.Field(default=None, description="Name of country")
     latitude: typing.Optional[float] = pydantic.Field(
-        default=None,
-        description="Latitude of address"
+        default=None, description="Latitude of address"
     )
     longitude: typing.Optional[float] = pydantic.Field(
-        default=None,
-        description="Longitude of address"
+        default=None, description="Longitude of address"
     )
 
     @pydantic.field_validator("line", mode="before")
@@ -371,11 +360,11 @@ class PIIRecord(StrippedBaseModel):
         Construct a PIIRecord from a Patient model.
         """
         return PIIRecord.from_data(patient.data)
-    
+
     @classmethod
     def from_data(cls, data: dict) -> typing.Self:
         """
-        Construct a PIIRecord from an extracted data dictionary of a 
+        Construct a PIIRecord from an extracted data dictionary of a
         Patient model.
         """
         obj = cls.model_construct(**data)
@@ -384,7 +373,6 @@ class PIIRecord(StrippedBaseModel):
         obj.telecom = [Telecom.model_construct(**t) for t in data.get("telecom", [])]
         obj.identifiers = [Identifier.model_construct(**i) for i in data.get("identifiers", [])]
         return obj
-
 
     def to_data(self) -> dict[str, typing.Any]:
         """
@@ -479,14 +467,14 @@ class PIIRecord(StrippedBaseModel):
     def feature_iter(self, feature: Feature, prepend_suffix: bool = False) -> typing.Iterator[str]:
         """
         Given a field name, return an iterator of all string values for that field.
-        Empty strings are not included in the iterator. Includes an optional 
+        Empty strings are not included in the iterator. Includes an optional
         parameter that can be used when invoking `feature_iter` on the FIRST_NAME
         field; if this parameter is true, the value yielded is the concatenation
         `SUFFIX + FIRST_NAME`.
 
-        :param prepend_suffix: An optional boolean indicating whether a suffix 
+        :param prepend_suffix: An optional boolean indicating whether a suffix
           should be prepended to a first name for blocking purposes. Has no
-          effect for features other than FIRST_NAME. 
+          effect for features other than FIRST_NAME.
         """
 
         if not isinstance(feature, Feature):
@@ -603,7 +591,12 @@ class PIIRecord(StrippedBaseModel):
             vals.update(self.feature_iter(Feature(attribute=FeatureAttribute.ZIP)))
         elif key == models.BlockingKey.FIRST_NAME:
             vals.update(
-                {x[:4] for x in self.feature_iter(Feature(attribute=FeatureAttribute.FIRST_NAME), prepend_suffix=True)}
+                {
+                    x[:4]
+                    for x in self.feature_iter(
+                        Feature(attribute=FeatureAttribute.FIRST_NAME), prepend_suffix=True
+                    )
+                }
             )
         elif key == models.BlockingKey.LAST_NAME:
             vals.update(
@@ -637,3 +630,24 @@ class PIIRecord(StrippedBaseModel):
             # a PII data dict could have multiple given names
             for val in self.blocking_keys(key):
                 yield key, val
+
+
+class TuningPair(pydantic.BaseModel):
+    """
+    A pair of PIIRecords that are used for training a model.
+    """
+
+    record1: PIIRecord
+    record2: PIIRecord
+    sample_used: typing.Optional[int] = None
+
+    @classmethod
+    def from_data(cls, record1: dict, record2: dict, sample_used: int | None = None) -> typing.Self:
+        """
+        Contruct a TuningPair from raw PII data dictionaries.
+        """
+        return cls.model_construct(
+            record1=PIIRecord.from_data(record1),
+            record2=PIIRecord.from_data(record2),
+            sample_used=sample_used,
+        )

--- a/src/recordlinker/schemas/tuning.py
+++ b/src/recordlinker/schemas/tuning.py
@@ -119,9 +119,10 @@ class TuningPair:
 @dataclasses.dataclass
 class TuningProbabilities:
     """
-    A dict of feature specific probabilities that two records are likely to belong to
-    the same cluster given a collection of TuningPairs. Also included are the number,
-    count, of TuningPairs analyzed and an optional parameter for sample size used.
+    A dictionary of class-conditional likelihoods separated by feature. For a given
+    feature F, this holds the probability that a pair of patient records in the same
+    tuning class (i.e. a true-match pair or a non-match pair) will have the same field
+    value in F.
     """
     probs: dict[Feature, float]  # the feature specific probabilities
     count: int  # the number of pairs analyzed

--- a/src/recordlinker/schemas/tuning.py
+++ b/src/recordlinker/schemas/tuning.py
@@ -5,6 +5,7 @@ recordlinker.schemas.tuning
 This module contains the schema definitions for the tuning jobs.
 """
 
+import dataclasses
 import datetime
 import typing
 import uuid
@@ -17,6 +18,8 @@ from recordlinker import models
 from recordlinker.utils.datetime import now_utc_no_ms
 
 from .algorithm import LogOdd
+from .pii import Feature
+from .pii import PIIRecord
 
 
 class TuningParams(pydantic.BaseModel):
@@ -90,3 +93,36 @@ class TuningJobResponse(TuningJob):
         """
         url: str = str(request.url_for("get-tuning-job", job_id=job.id))
         return cls(**job.model_dump(), status_url=pydantic.HttpUrl(url))
+
+
+@dataclasses.dataclass
+class TuningPair:
+    """
+    A pair of PIIRecords that are used for training a model.
+    """
+    record1: PIIRecord
+    record2: PIIRecord
+    sample_used: typing.Optional[int] = None  # the number of records sampled from to produce the pair
+
+    @classmethod
+    def from_data(cls, record1: dict, record2: dict, sample_used: int | None = None) -> typing.Self:
+        """
+        Contruct a TuningPair from raw PII data dictionaries.
+        """
+        return cls(
+            record1=PIIRecord.from_data(record1),
+            record2=PIIRecord.from_data(record2),
+            sample_used=sample_used,
+        )
+
+
+@dataclasses.dataclass
+class TuningProbabilities:
+    """
+    A dict of feature specific probabilities that two records are likely to belong to
+    the same cluster given a collection of TuningPairs. Also included are the number,
+    count, of TuningPairs analyzed and an optional parameter for sample size used.
+    """
+    probs: dict[Feature, float]  # the feature specific probabilities
+    count: int  # the number of pairs analyzed
+    sample_used: typing.Optional[int] = None  # the number of records sampled from to produce the probabilities

--- a/src/recordlinker/tuning/base.py
+++ b/src/recordlinker/tuning/base.py
@@ -9,6 +9,8 @@ import logging
 import typing
 import uuid
 
+from sqlalchemy import orm
+
 from recordlinker import models
 from recordlinker import schemas
 from recordlinker.database import get_session_manager
@@ -20,7 +22,6 @@ from recordlinker.tuning import prob_calc
 LOGGER = logging.getLogger(__name__)
 
 
-# TODO: test cases
 async def tune(job_id: uuid.UUID, session_factory: typing.Optional[typing.Callable] = None) -> None:
     """
     Run log-odds tuning calculations
@@ -36,63 +37,11 @@ async def tune(job_id: uuid.UUID, session_factory: typing.Optional[typing.Callab
             tuning_service.update_job(session, job, models.TuningStatus.RUNNING)
             results: schemas.TuningResults = schemas.TuningResults()
 
-            # Step 1: Acquire class-partitioned data samples and update
-            # results information with number of pairs actually used
-            true_iter: typing.Iterator[schemas.TuningPair] = (
-                mpi_service.generate_true_match_tuning_samples(
-                    session,
-                    job.params.true_match_pairs_requested,
-                )
-            )
-            true_pairs: list[schemas.TuningPair] = list(true_iter)
-            non_iter: typing.Iterator[schemas.TuningPair] = (
-                mpi_service.generate_non_match_tuning_samples(
-                    session,
-                    sample_size=job.params.non_match_sample_requested,
-                    n_pairs=job.params.non_match_pairs_requested,
-                )
-            )
-            non_pairs: list[schemas.TuningPair] = list(non_iter)
-            sample_used: int = non_pairs[0].sample_used if non_pairs else 0
-            results.true_match_pairs_used = len(true_pairs)
-            results.non_match_pairs_used = len(non_pairs)
-            results.non_match_sample_used = sample_used
-
-            # Step 2: Compute class-specific probabilities
-            m_probs: dict[str, float] = prob_calc.calculate_class_probs(true_pairs)
-            u_probs: dict[str, float] = prob_calc.calculate_class_probs(non_pairs)
-
-            # Step 3: Compute log-odds
-            log_odds: dict[str, float] = prob_calc.calculate_log_odds(
-                m_probs=m_probs, u_probs=u_probs
-            )
-            results.log_odds = [
-                schemas.LogOdd(feature=schemas.Feature.parse(k), value=v)
-                for k, v in log_odds.items()
-            ]
-
-            # Step 4: Compute suggested RMS possible match window boundaries
-            obj: models.Algorithm | None = default_algorithm(session)
-            assert obj is not None
-            algorithm: schemas.Algorithm = schemas.Algorithm.model_validate(obj)
-            sorted_scores: dict[str, typing.Tuple[list[float], list[float]]] = (
-                prob_calc.calculate_and_sort_tuning_scores(
-                    true_pairs, non_pairs, log_odds, algorithm
-                )
-            )
-            rms_bounds: dict[str, typing.Tuple[float, float]] = prob_calc.estimate_rms_bounds(
-                sorted_scores
-            )
-            pass_recs: list[schemas.PassRecommendation] = []
-            for idx, algorithm_pass in enumerate(algorithm.passes):
-                pass_name: str = algorithm_pass.label or f"pass_{idx}"  # type: ignore
-                rec = schemas.PassRecommendation(
-                    algorithm_label=algorithm.label,
-                    pass_label=pass_name,
-                    recommended_match_window=rms_bounds[pass_name],
-                )
-                pass_recs.append(rec)
-            results.passes = pass_recs
+            (true_count, non_count, non_sample, log_odds) = run_log_odds(session, job.params)
+            results.true_match_pairs_used = true_count
+            results.non_match_pairs_used = non_count
+            results.non_match_sample_used = non_sample
+            results.passes = run_rms(session, job.params, results.log_odds)
 
             tuning_service.update_job(session, job, models.TuningStatus.COMPLETED, results)
         except Exception as exc:
@@ -100,3 +49,101 @@ async def tune(job_id: uuid.UUID, session_factory: typing.Optional[typing.Callab
                 "tuning job failed", extra={"job_id": job_id, "exc": str(exc)}, exc_info=True
             )
             tuning_service.fail_job(session, job_id, str(exc))
+
+
+def run_log_odds(
+    session: orm.Session, params: schemas.TuningParams
+) -> typing.Tuple[int, int, int, typing.Sequence[schemas.LogOdd]]:
+    """
+    Run log-odds tuning calculations
+
+    :param session: database session
+    :param params: tuning parameters
+
+    :returns: A tuple of the form (true_match_count, non_match_count,
+      sample_used, log_odds)
+    """
+    # Step 1: Acquire class-partitioned data samples and update
+    # results information with number of pairs actually used
+    true_pairs: typing.Iterator[prob_calc.TuningPair] = (
+        mpi_service.generate_true_match_tuning_samples(
+            session,
+            params.true_match_pairs_requested,
+        )
+    )
+    non_pairs: typing.Iterator[prob_calc.TuningPair] = (
+        mpi_service.generate_non_match_tuning_samples(
+            session,
+            sample_size=params.non_match_sample_requested,
+            n_pairs=params.non_match_pairs_requested,
+        )
+    )
+
+    # Step 2: Compute class-specific probabilities
+    m_results: schemas.TuningProbabilities = prob_calc.calculate_class_probs(true_pairs)
+    u_results: schemas.TuningProbabilities = prob_calc.calculate_class_probs(non_pairs)
+
+    # Step 3: Compute log-odds
+    log_odds: dict[schemas.Feature, float] = prob_calc.calculate_log_odds(
+        m_probs=m_results.probs, u_probs=u_results.probs
+    )
+
+    return (
+        m_results.count,
+        u_results.count,
+        u_results.sample_used or 0,
+        [schemas.LogOdd(feature=f, value=v) for f, v in log_odds.items()],
+    )
+
+
+def run_rms(
+    session: orm.Session, params: schemas.TuningParams, log_odds: typing.Sequence[schemas.LogOdd]
+) -> typing.Sequence[schemas.PassRecommendation]:
+    """
+    Run RMS tuning calculations
+
+    :param session: database session
+    :param params: tuning parameters
+    :param log_odds: log-odds values
+
+    :returns: A sequence of PassRecommendation
+    """
+    obj: models.Algorithm | None = default_algorithm(session)
+    if obj is None:
+        # No default Algorithm found, so no RMS tuning can be performed
+        return []
+
+    algorithm: schemas.Algorithm = schemas.Algorithm.model_validate(obj)
+    log_odds_map: dict[schemas.Feature, float] = {f.feature: f.value for f in log_odds}
+
+    # Step 1: Acquire class-partitioned data samples and update
+    # results information with number of pairs actually used
+    true_pairs: typing.Iterator[prob_calc.TuningPair] = (
+        mpi_service.generate_true_match_tuning_samples(
+            session,
+            params.true_match_pairs_requested,
+        )
+    )
+    non_pairs: typing.Iterator[prob_calc.TuningPair] = (
+        mpi_service.generate_non_match_tuning_samples(
+            session,
+            sample_size=params.non_match_sample_requested,
+            n_pairs=params.non_match_pairs_requested,
+        )
+    )
+
+    # Step 2: Compute suggested RMS possible match window boundaries
+    sorted_scores: dict[str, typing.Tuple[list[float], list[float]]] = (
+        prob_calc.calculate_and_sort_tuning_scores(true_pairs, non_pairs, log_odds_map, algorithm)
+    )
+    rms_bounds: dict[str, typing.Tuple[float, float]] = prob_calc.estimate_rms_bounds(sorted_scores)
+    pass_recs: list[schemas.PassRecommendation] = []
+    for idx, algorithm_pass in enumerate(algorithm.passes):
+        pass_name: str = algorithm_pass.resolved_label
+        rec = schemas.PassRecommendation(
+            algorithm_label=algorithm.label,
+            pass_label=pass_name,
+            recommended_match_window=rms_bounds[pass_name],
+        )
+        pass_recs.append(rec)
+    return pass_recs

--- a/src/recordlinker/tuning/base.py
+++ b/src/recordlinker/tuning/base.py
@@ -38,26 +38,22 @@ async def tune(job_id: uuid.UUID, session_factory: typing.Optional[typing.Callab
 
             # Step 1: Acquire class-partitioned data samples and update
             # results information with number of pairs actually used
-            true_iter: typing.Iterator[typing.Tuple[dict, dict]] = (
+            true_iter: typing.Iterator[schemas.TuningPair] = (
                 mpi_service.generate_true_match_tuning_samples(
                     session,
                     job.params.true_match_pairs_requested,
                 )
             )
-            true_pairs: list[typing.Tuple[dict, dict]] = list(true_iter)
-            non_iter: typing.Iterator[typing.Tuple[typing.Tuple[dict, dict], int]] = (
+            true_pairs: list[schemas.TuningPair] = list(true_iter)
+            non_iter: typing.Iterator[schemas.TuningPair] = (
                 mpi_service.generate_non_match_tuning_samples(
                     session,
                     sample_size=job.params.non_match_sample_requested,
                     n_pairs=job.params.non_match_pairs_requested,
                 )
             )
-            non_pairs: list[typing.Tuple[dict, dict]] = []
-            sample_used: int = 0
-            for pair, found in non_iter:
-                non_pairs.append(pair)
-                if not sample_used:
-                    sample_used = found
+            non_pairs: list[schemas.TuningPair] = list(non_iter)
+            sample_used: int = non_pairs[0].sample_used if non_pairs else 0
             results.true_match_pairs_used = len(true_pairs)
             results.non_match_pairs_used = len(non_pairs)
             results.non_match_sample_used = sample_used

--- a/src/recordlinker/tuning/prob_calc.py
+++ b/src/recordlinker/tuning/prob_calc.py
@@ -110,9 +110,7 @@ def calculate_and_sort_tuning_scores(
     # need to iterate over the pairs first, then the passes
     for pair in true_match_pairs:
         for key, score in _score_records_in_pair(pair, log_odds, max_points, algorithm).items():
-            if score > 0.0:
-                # ignore true-matches with no agreement
-                sorted_scores[key][0].append(score)
+            sorted_scores[key][0].append(score)
     for pair in non_match_pairs:
         for key, score in _score_records_in_pair(pair, log_odds, max_points, algorithm).items():
             sorted_scores[key][1].append(score)
@@ -145,7 +143,7 @@ def estimate_rms_bounds(
         # Don't count any vacuous 0s in the true match class towards the boundary
         # of minimum thresholding--we want the MMT to apply to the real bulk of
         # the distribution farther down the axis
-        true_match_scores = sorted_scores[k][0]
+        true_match_scores = [x for x in sorted_scores[k][0] if x > 0.0]
         non_match_scores = sorted_scores[k][1]
 
         # Overlap the lists to find the possible match window:

--- a/src/recordlinker/tuning/prob_calc.py
+++ b/src/recordlinker/tuning/prob_calc.py
@@ -7,7 +7,8 @@ from recordlinker.schemas import algorithm as ag
 from recordlinker.schemas.pii import Feature
 from recordlinker.schemas.pii import FeatureAttribute
 from recordlinker.schemas.pii import PIIRecord
-from recordlinker.schemas.pii import TuningPair
+from recordlinker.schemas.tuning import TuningPair
+from recordlinker.schemas.tuning import TuningProbabilities
 
 # We don't need log-odds for every Feature we register, since some
 # are folded into other evaluations
@@ -16,9 +17,8 @@ FIELDS_TO_CALCULATE = [
     Feature.parse(f.value) for f in FeatureAttribute if f.value not in FIELDS_TO_IGNORE
 ]
 
-def calculate_class_probs(
-        sampled_pairs: typing.Sequence[TuningPair]
-    ) -> dict[str, float]:
+
+def calculate_class_probs(sampled_pairs: typing.Iterable[TuningPair]) -> TuningProbabilities:
     """
     Calculate the class-conditional likelihood that two records will
     agree on a particular field, given that the two records are a
@@ -26,36 +26,35 @@ def calculate_class_probs(
     This function is used to calculate both the m- and u-probabilities,
     depending on the pair sample it is given.
 
-    :param sampled_pairs: A sequence of tuples containing pairs 
-      of patient data dictionaries.
-    :returns: A dictionary mapping Feature names to their class
-      probabilities.
+    :param sampled_pairs: An iterable of TuningPairs
+    :returns: A TuningProbabilities object
     """
     # LaPlacian smoothing accounts for unseen instances
-    class_probs = {str(f): 1.0 for f in FIELDS_TO_CALCULATE}
-    count: int = 0
+    result: TuningProbabilities = TuningProbabilities(
+        probs={f: 1.0 for f in FIELDS_TO_CALCULATE}, count=0
+    )
 
     for pair in sampled_pairs:
         # The probabilistic exact matcher nicely uses feature_iter and
         # cross-value checking for us; if we award 0 points for missing
         # data and 1 point for perfect agreement, we get the count
-        count += 1
+        result.count += 1
+        result.sample_used = pair.sample_used
         for f in FIELDS_TO_CALCULATE:
             comparison, _ = compare_probabilistic_exact_match(
                 pair.record1, pair.record2, f, 1.0, 0.0, prepend_suffix=False
             )
-            class_probs[str(f)] += comparison
-    
-    for k in class_probs:
-        class_probs[k] /= float(count + 1)
-    
-    return class_probs
+            result.probs[f] += comparison
+
+    for f in result.probs:
+        result.probs[f] /= float(result.count + 1)
+
+    return result
 
 
 def calculate_log_odds(
-        m_probs: dict[str, float],
-        u_probs: dict[str, float]
-    ) -> dict[str, float]:
+    m_probs: dict[Feature, float], u_probs: dict[Feature, float]
+) -> dict[Feature, float]:
     """
     Given class-conditional probabilities for field agreement, calculate
     the log-odds values for each field of calculable interest for
@@ -67,29 +66,29 @@ def calculate_log_odds(
       given two records are not a match.
     :returns: A dictionary mapping Feature names to their log-odds values.
     """
-    log_odds = {}
+    log_odds: dict[Feature, float] = {}
     for field in m_probs:
         log_odds[field] = math.log(m_probs[field] / u_probs[field])
     return log_odds
 
 
 def calculate_and_sort_tuning_scores(
-    true_match_pairs: typing.Sequence[TuningPair],
-    non_match_pairs: typing.Sequence[TuningPair],
-    log_odds: dict[str, float],
-    algorithm: ag.Algorithm
+    true_match_pairs: typing.Iterable[TuningPair],
+    non_match_pairs: typing.Iterable[TuningPair],
+    log_odds: dict[Feature, float],
+    algorithm: ag.Algorithm,
 ) -> dict[str, typing.Tuple[list[float], list[float]]]:
     """
     Given a set of true-matching pairs and a set of non-matching pairs
     obtained from database sampling, calculates the pairwise RMS for
-    each collection, for each pass of the algorithm, and sorts the 
+    each collection, for each pass of the algorithm, and sorts the
     resulting scores. The evaluation steps of the given algorithm are
     invoked on each pair of each class, using the provided log-odds
     to compute RMS.
 
-    :param true_match_pairs: A sequence of TuningPairs containing known
+    :param true_match_pairs: An iterable of TuningPairs containing known
       matching pairs of patient data dictionaries.
-    :param non_match_pairs: A sequence of TuningPairs containing known non-
+    :param non_match_pairs: An iterable of TuningPairs containing known non-
       matching pairs of patient data dictionaries.
     :param log_odds: A dictionary mapping Feature string names to their
       computed log-odds values.
@@ -98,36 +97,38 @@ def calculate_and_sort_tuning_scores(
     :returns: A dictonary mapping the names of the algorithm's passes to
       a tuple containing sorted lists of class RMS scores.
     """
-    context: ag.AlgorithmContext = algorithm.algorithm_context
-    sorted_scores = {}
+    sorted_scores: dict[str, typing.Tuple[list[float], list[float]]] = {
+        p.resolved_label: ([], []) for p in algorithm.passes
+    }
+    max_points: dict[str, float] = {
+        p.resolved_label: sum([log_odds.get(e.feature, 0.0) for e in p.evaluators])
+        for p in algorithm.passes
+    }
 
-    # Tuning generates results per pass, so we'll generate one result set
-    # per pass of the given algorithm
-    for idx, algorithm_pass in enumerate(algorithm.passes):
-        max_points_in_pass: float = sum(
-            [log_odds[str(e.feature)] or 0.0 for e in algorithm_pass.evaluators]
-        )
-        true_match_scores: list[float] = _score_pairs_in_class(
-            true_match_pairs, log_odds, max_points_in_pass, algorithm_pass, context
-        )
-        non_match_scores: list[float] = _score_pairs_in_class(
-            non_match_pairs, log_odds, max_points_in_pass, algorithm_pass, context
-        )
-        true_match_scores = sorted(true_match_scores)
-        non_match_scores = sorted(non_match_scores)
-        sorted_scores[
-            algorithm_pass.label or f"pass_{idx}"
-        ] = (true_match_scores, non_match_scores)
+    # Both true-match and non-match pairs are iterables and can only be accessed once,
+    # we need to use the pairs to calculate values for all passes in the Algorithm, thus we
+    # need to iterate over the pairs first, then the passes
+    for pair in true_match_pairs:
+        for key, score in _score_records_in_pair(pair, log_odds, max_points, algorithm).items():
+            sorted_scores[key][0].append(score)
+    for pair in non_match_pairs:
+        for key, score in _score_records_in_pair(pair, log_odds, max_points, algorithm).items():
+            sorted_scores[key][1].append(score)
+
+    for key in sorted_scores:
+        sorted_scores[key][0].sort()
+        sorted_scores[key][1].sort()
+
     return sorted_scores
 
 
 def estimate_rms_bounds(
-    sorted_scores: dict[str, typing.Tuple[list[float], list[float]]]
+    sorted_scores: dict[str, typing.Tuple[list[float], list[float]]],
 ) -> dict[str, typing.Tuple[float, float]]:
     """
     Identifies suggested boundaries for the RMS possible match windows
     of each pass of an algorithm, using previously sampled pairs of
-    true and non matches. 
+    true and non matches.
 
     :param sorted_scores: A dictionary mapping the names of the passes of
       a linkage algorithm to a tuple containing class-partitioned lists
@@ -159,13 +160,13 @@ def estimate_rms_bounds(
                 cmt = t
                 break
 
-        # To account for unseen data, buffer each threshold by pushing it 
+        # To account for unseen data, buffer each threshold by pushing it
         # towards its respective distribution's extreme
         if mmt is not None:
             mmt = max([0, mmt - 0.025])
         if cmt is not None:
             cmt = min([1.0, cmt + 0.025])
-        
+
         # Edge Case 1: Distributions are totally disjoint
         # MMT can just be set to the highest non-match score
         if mmt is None:
@@ -174,14 +175,14 @@ def estimate_rms_bounds(
         # Edge Case 2: No true match score larger than largest non-match
         # This is EXTREMELY unnatural and can only happen if either the
         # distributions are inverted (true match scores left of non-match
-        # scores) or the true-match curve is a subset contained entirely 
+        # scores) or the true-match curve is a subset contained entirely
         # within the non-match curve--in either case, the problem is likely
         # the data and not the scoring procedure
         if cmt is None:
             # Best we can do is set the CMT to be beyond the range of the
             # non-match curve
             cmt = min([non_match_scores[-1] + 0.01, 1.0])
-        
+
         suggested_bounds[k] = (mmt, cmt)
     return suggested_bounds
 
@@ -189,7 +190,7 @@ def estimate_rms_bounds(
 def _compare_records_in_pair(
     record_1: PIIRecord,
     record_2: PIIRecord,
-    log_odds: dict[str, float],
+    log_odds: dict[Feature, float],
     max_log_odds_points: float,
     algorithm_pass: ag.AlgorithmPass,
     context: ag.AlgorithmContext,
@@ -208,7 +209,7 @@ def _compare_records_in_pair(
     :param max_log_odds_points: The maximum number of log-odds points that can
       be scored in the pass of the algorithm in which the records are being
       compared.
-    :param algorithm_pass: The schema for the algorithm pass in which the 
+    :param algorithm_pass: The schema for the algorithm pass in which the
       records are being compared.
     :param context: The schema for the algorithm context being used.
     :returns: The number of log-odds points earned by the comparison between
@@ -218,7 +219,7 @@ def _compare_records_in_pair(
     results: list[float] = []
     max_missing_proportion: float = context.advanced.max_missing_allowed_proportion
     for evaluator in algorithm_pass.evaluators:
-        log_odds_for_field: float = log_odds[str(evaluator.feature)] or 0.0
+        log_odds_for_field: float = log_odds.get(evaluator.feature, 0.0)
         # Evaluate the comparison function, track missingness, and append the
         # score component to the list
         fn: typing.Callable = evaluator.func.callable()
@@ -245,45 +246,31 @@ def _compare_records_in_pair(
     return rule_result
 
 
-def _score_pairs_in_class(
-        class_sample: typing.Sequence[TuningPair],
-        log_odds: dict[str, float],
-        max_points: float,
-        algorithm_pass: ag.AlgorithmPass,
-        context: ag.AlgorithmContext,
-    ) -> list[float]:
+def _score_records_in_pair(
+    pair: TuningPair,
+    log_odds: dict[Feature, float],
+    max_points: dict[str, float],
+    algorithm: ag.Algorithm,
+) -> dict[str, float]:
     """
-    Given a sample of class-partitioned data and a single pass of a record
-    linkage algorithm, compute the RMS of each pair in the class sample 
-    when evaluated on just that pass. 
+    Given a TuningPair and an Algorithm, calculate the RMS for each pass.
 
-    :param class_sample: A sequence of tuples of pairs of patient data
-      dictionaries, each belonging to the same class of tuning data (either
-      known true-match or known non-match).
-    :param log_odds: A dictionary mapping Feature string names to their 
+    :param pair: A TuningPair containing two patient records.
+    :param log_odds: A dictionary mapping Feature string names to their
       calculated log-odds values.
-    :param max_points: A dictionary mapping the name of each pass of an 
-      algorithm to the maximum possible number of log-odds points obtainable
-      in that pass.
-    :param algorithm_pass: The schema for one pass of an algorithm to use
-      for comparing the record pairs.
-    :param context: The schema for an algorithm context to use.
-    :returns: A list of RMS values, one for each input pair.
+    :param max_points: A dictionary mapping the names of the algorithm's
+      passes to the maximum number of log-odds points that can be scored in
+      the pass.
+    :param algorithm: A schema defining an algorithm to use for estimating
+      RMS threshold boundaries.
+    :returns: A dictionary mapping the names of the algorithm's passes to
     """
-    class_scores: list[float] = []
-    for pair in class_sample:
-        pii_record_1 = remove_skip_values(pair.record1, context.skip_values)
-        pii_record_2 = remove_skip_values(pair.record2, context.skip_values)
-
-        # Find the score for this pair using just the evaluators of the pass
-        # we were given
-        score_in_pass = _compare_records_in_pair(
-            pii_record_1,
-            pii_record_2,
-            log_odds,
-            max_points,
-            algorithm_pass,
-            context
-        )
-        class_scores.append(score_in_pass / max_points)
-    return class_scores
+    result: dict[str, float] = {}
+    ctx: ag.AlgorithmContext = algorithm.algorithm_context
+    rec1: PIIRecord = remove_skip_values(pair.record1, ctx.skip_values)
+    rec2: PIIRecord = remove_skip_values(pair.record2, ctx.skip_values)
+    for _pass in algorithm.passes:
+        key: str = _pass.resolved_label
+        val: float = _compare_records_in_pair(rec1, rec2, log_odds, max_points[key], _pass, ctx)
+        result[key] = val / max_points[key] if max_points[key] else 0.0
+    return result

--- a/tests/unit/database/test_mpi_service.py
+++ b/tests/unit/database/test_mpi_service.py
@@ -1222,7 +1222,8 @@ class TestGenerateTuningClasses:
     def test_generate_true_match_samples(self, client):
         data = load_test_json_asset("100_cluster_tuning_test.json.gz")
         client.post(self.path(client), json=data)
-        sample_pairs = mpi_service.generate_true_match_tuning_samples(client.session, 5)
+        pair_iter = mpi_service.generate_true_match_tuning_samples(client.session, 5)
+        sample_pairs = list(pair_iter)
         assert len(sample_pairs) == 5
         for pair in sample_pairs:
             assert type(pair) is tuple
@@ -1232,7 +1233,12 @@ class TestGenerateTuningClasses:
     def test_generate_non_match_samples(self, client):
         data = load_test_json_asset("100_cluster_tuning_test.json.gz")
         client.post(self.path(client), json=data)
-        sample_pairs, sample_used = mpi_service.generate_non_match_tuning_samples(client.session, 1500, 5)
+        pair_iter = mpi_service.generate_non_match_tuning_samples(client.session, 1500, 5)
+        sample_pairs = []
+        sample_used = 0
+        for pair, found in pair_iter:
+            sample_pairs.append(pair)
+            sample_used = found
         assert sample_used == 699
         assert len(sample_pairs) == 5
         for pair in sample_pairs:
@@ -1244,11 +1250,11 @@ class TestGenerateTuningClasses:
         data = load_test_json_asset("100_cluster_tuning_test.json.gz")
         client.post(self.path(client), json=data)
         with pytest.raises(ValueError):
-            mpi_service.generate_non_match_tuning_samples(client.session, 500, 500)
+            list(mpi_service.generate_non_match_tuning_samples(client.session, 500, 500))
 
     def test_generate_non_match_samples_taylor_error(self, client):
         data = load_test_json_asset("100_cluster_tuning_test.json.gz")
         client.post(self.path(client), json=data)
         with pytest.raises(ValueError):
-            mpi_service.generate_non_match_tuning_samples(client.session, 1, 1)
+            list(mpi_service.generate_non_match_tuning_samples(client.session, 1, 1))
 

--- a/tests/unit/tuning/test_prob_calc.py
+++ b/tests/unit/tuning/test_prob_calc.py
@@ -2,10 +2,9 @@ import pytest
 from conftest import load_test_json_asset
 
 from recordlinker.linking.skip_values import remove_skip_values
-from recordlinker.schemas.pii import PIIRecord
-from recordlinker.schemas.pii import TuningPair
+from recordlinker.schemas.pii import Feature
+from recordlinker.schemas.tuning import TuningPair
 from recordlinker.tuning.prob_calc import _compare_records_in_pair
-from recordlinker.tuning.prob_calc import _score_pairs_in_class
 from recordlinker.tuning.prob_calc import calculate_and_sort_tuning_scores
 from recordlinker.tuning.prob_calc import calculate_class_probs
 from recordlinker.tuning.prob_calc import calculate_log_odds
@@ -38,41 +37,41 @@ def non_match_samples():
 
 class TestTuningProbabilityCalculators:
     def test_calculate_class_probs_m(self, true_match_samples):
-        m_probs = calculate_class_probs(true_match_samples)
+        m_probs = calculate_class_probs(true_match_samples).probs
         assert m_probs == {
-            'BIRTHDATE': (2.0 / 3.0),
-            'SEX': (5.0 / 6.0),
-            'FIRST_NAME': (5.0 / 6.0),
-            'LAST_NAME': 1.0,
-            'ADDRESS': 1.0,
-            'CITY': (2.0 / 3.0),
-            'STATE': 1.0,
-            'ZIP': (5.0 / 6.0),
-            'RACE': 1.0,
-            'TELECOM': 1.0,
-            'PHONE': 1.0,
-            'EMAIL': (1.0 / 6.0),
-            'COUNTY': 1.0,
-            'IDENTIFIER': 1.0
+            Feature.parse('BIRTHDATE'): (2.0 / 3.0),
+            Feature.parse('SEX'): (5.0 / 6.0),
+            Feature.parse('FIRST_NAME'): (5.0 / 6.0),
+            Feature.parse('LAST_NAME'): 1.0,
+            Feature.parse('ADDRESS'): 1.0,
+            Feature.parse('CITY'): (2.0 / 3.0),
+            Feature.parse('STATE'): 1.0,
+            Feature.parse('ZIP'): (5.0 / 6.0),
+            Feature.parse('RACE'): 1.0,
+            Feature.parse('TELECOM'): 1.0,
+            Feature.parse('PHONE'): 1.0,
+            Feature.parse('EMAIL'): (1.0 / 6.0),
+            Feature.parse('COUNTY'): 1.0,
+            Feature.parse('IDENTIFIER'): 1.0
         }
 
     def test_calculate_class_probs_u(self, non_match_samples):
-        u_probs = calculate_class_probs(non_match_samples)
+        u_probs = calculate_class_probs(non_match_samples).probs
         assert u_probs == {
-            'BIRTHDATE': (1.0 / 6.0),
-            'SEX': (1.0 / 3.0),
-            'FIRST_NAME': (1.0 / 6.0),
-            'LAST_NAME': (1.0 / 6.0),
-            'ADDRESS': (1.0 / 6.0),
-            'CITY': (1.0 / 6.0),
-            'STATE': (1.0 / 3.0),
-            'ZIP': (1.0 / 6.0),
-            'RACE': (1.0 / 3.0),
-            'TELECOM': (1.0 / 6.0),
-            'PHONE': (1.0 / 6.0),
-            'EMAIL': (1.0 / 6.0),
-            'COUNTY': (1.0 / 6.0),
-            'IDENTIFIER': (1.0 / 6.0)
+            Feature.parse('BIRTHDATE'): (1.0 / 6.0),
+            Feature.parse('SEX'): (1.0 / 3.0),
+            Feature.parse('FIRST_NAME'): (1.0 / 6.0),
+            Feature.parse('LAST_NAME'): (1.0 / 6.0),
+            Feature.parse('ADDRESS'): (1.0 / 6.0),
+            Feature.parse('CITY'): (1.0 / 6.0),
+            Feature.parse('STATE'): (1.0 / 3.0),
+            Feature.parse('ZIP'): (1.0 / 6.0),
+            Feature.parse('RACE'): (1.0 / 3.0),
+            Feature.parse('TELECOM'): (1.0 / 6.0),
+            Feature.parse('PHONE'): (1.0 / 6.0),
+            Feature.parse('EMAIL'): (1.0 / 6.0),
+            Feature.parse('COUNTY'): (1.0 / 6.0),
+            Feature.parse('IDENTIFIER'): (1.0 / 6.0)
         }
 
     def test_calculate_log_odds(self):
@@ -130,29 +129,27 @@ class TestScoreTuningSamples:
     @pytest.fixture
     def log_odds(self):
         return {
-            'BIRTHDATE': 1.386,
-            'SEX': 0.916,
-            'FIRST_NAME': 1.609,
-            'LAST_NAME': 1.792,
-            'ADDRESS': 1.792,
-            'CITY': 1.386,
-            'STATE': 1.099,
-            'ZIP': 1.609,
-            'RACE': 1.099,
-            'TELECOM': 1.792,
-            'PHONE': 1.792,
-            'EMAIL': 0.0,
-            'COUNTY': 1.792,
-            'IDENTIFIER': 1.792,
+            Feature.parse('BIRTHDATE'): 1.386,
+            Feature.parse('SEX'): 0.916,
+            Feature.parse('FIRST_NAME'): 1.609,
+            Feature.parse('LAST_NAME'): 1.792,
+            Feature.parse('ADDRESS'): 1.792,
+            Feature.parse('CITY'): 1.386,
+            Feature.parse('STATE'): 1.099,
+            Feature.parse('ZIP'): 1.609,
+            Feature.parse('RACE'): 1.099,
+            Feature.parse('TELECOM'): 1.792,
+            Feature.parse('PHONE'): 1.792,
+            Feature.parse('EMAIL'): 0.0,
+            Feature.parse('COUNTY'): 1.792,
+            Feature.parse('IDENTIFIER'): 1.792,
         }
 
     def test_compare_records_in_pair(self, default_algorithm, log_odds, true_match_samples, non_match_samples):
 
         context = default_algorithm.algorithm_context
         pass_1 = default_algorithm.passes[0]
-        max_points = sum(
-            [log_odds[str(e.feature)] or 0.0 for e in pass_1.evaluators]
-        )
+        max_points = sum([log_odds[e.feature] for e in pass_1.evaluators])
 
         # Run one check of comparisons on a true match pair
         # Fields should all line up, should be max
@@ -167,23 +164,6 @@ class TestScoreTuningSamples:
         pii_record_2 = remove_skip_values(non_match_samples[0].record2, context.skip_values)
         result = _compare_records_in_pair(pii_record_1, pii_record_2, log_odds, max_points, pass_1, context)
         assert result == 0.0
-
-    def test_score_pairs_in_class(self, default_algorithm, log_odds, true_match_samples, non_match_samples):
-        context = default_algorithm.algorithm_context
-        for idx, algorithm_pass in enumerate(default_algorithm.passes):
-            max_points_in_pass: float = sum(
-                [log_odds[str(e.feature)] or 0.0 for e in algorithm_pass.evaluators]
-            )
-            true_scores = _score_pairs_in_class(true_match_samples, log_odds, max_points_in_pass, algorithm_pass, context)
-            true_scores = [round(x, 3) for x in true_scores]
-            non_match_scores = _score_pairs_in_class(non_match_samples, log_odds, max_points_in_pass, algorithm_pass, context)
-            # Scores for first pass
-            if idx == 0:
-                assert true_scores == [1.0, 1.0, 1.0, 0.527, 1.0]
-                assert non_match_scores == [0.0] * 5
-            else:
-                assert true_scores == [1.0, 1.0, 0.564, 0.564, 1.0]
-                assert non_match_scores == [0.0] * 5
     
     def test_calculate_and_sort_tuning_scores(self, default_algorithm, log_odds, true_match_samples, non_match_samples):
         sorted_scores = calculate_and_sort_tuning_scores(


### PR DESCRIPTION
## Description
Optimizing memory usage by ~70% in tuning calculations using iterators.

## Related Issues
closes #456

## Additional Notes
- I couple of dataclasses were added to schemas/tuning to help with passing data between prob_calc and base.  TuningPair and TuningProbabilities.  The former is particularly helpful with a shift to iterators, as it's no longer possible to return values from the mpi_service queries.
- AlgorithmPass.resolved_label was added to help with type checks, as that guarantees a string will be returned (AlgorithmPass.label, could be null)
- Feature was configured to be "frozen" (meaning once a Feature object is instantiated, it can't be changed).  This is useful as we can now use them as keys in our log-odds dicts, rather than the feature string values as the keys.  This reduced the number of time we need to convert back and forth between strings and Features.
- tuning/base::tune was split to use 2 sub-functions, run_log_odds and run_rms.  With an iterators version, we need to gather true-match and non-match pairs from the database twice.  Separating the calculations into two functions makes it clearer as to where the pairs are being used.
- The looping constructs in calculate_and_sort_tuning_scores we essentially reversed.  Previously we looped over all the algorithm passes, then we looped over the pairs.  Now that we have iterators, that doesn't work, as we can only access the pair once.  To accomplish this, we now loop over the pairs, then loop over the algorithm passes.  _score_pairs_in_class was renamed to _score_records_in_pair as now it just performs the value on 1 pair over N passes.

## Performance Notes
Results from running tuning job tests with a 500k cluster using the default params.

### main stats
runtime: 42s
max memory: 665MB

### PR-469 stats
runtime: 44s
max memory: 204MB
<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
