### PR TITLE
fix tuning job timeout

### DIFF
--- a/src/recordlinker/routes/tuning_router.py
+++ b/src/recordlinker/routes/tuning_router.py
@@ -31,7 +31,7 @@ async def run_tune_job(job_id: uuid.UUID):
     """
     timeout: int = settings.tuning_job_timeout
     try:
-        await asyncio.wait_for(tune(job_id), timeout=timeout)
+        await asyncio.wait_for(asyncio.to_thread(tune, job_id), timeout=timeout)
     except Exception as exc:
         # Tuning job either failed on its own, or ran out of time.
         # In either case, we're going to log the error, mark the job

--- a/src/recordlinker/tuning/base.py
+++ b/src/recordlinker/tuning/base.py
@@ -21,7 +21,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 # TODO: test cases
-async def tune(job_id: uuid.UUID, session_factory: typing.Optional[typing.Callable] = None) -> None:
+def tune(job_id: uuid.UUID, session_factory: typing.Optional[typing.Callable] = None) -> None:
     """
     Run log-odds tuning calculations
     """


### PR DESCRIPTION
## Description
Fix tuning job timeout to properly cancel job if time is exceeded

## Related Issues
closes #464

## Additional Notes
Using asyncio.wait_for will only timeout if the calling function yields control back to the caller, typically with some IO operation.  Tuning is heavily CPU bound, after the initial queries.  By converting the call to run the tuning operations in a separate thread, we can still enforce a timeout if the process takes too long.

<--------------------- REMOVE THE LINES BELOW BEFORE MERGING --------------------->

## Checklist
Please review and complete the following checklist before submitting your pull request:

- [x] I have ensured that the pull request is of a manageable size, allowing it to be reviewed within a single session.
- [x] I have reviewed my changes to ensure they are clear, concise, and well-documented.
- [x] I have updated the documentation, if applicable.
- [x] I have added or updated test cases to cover my changes, if applicable.
- [x] I have minimized the number of reviewers to include only those essential for the review.

## Checklist for Reviewers
Please review and complete the following checklist during the review process:

- [ ] The code follows best practices and conventions.
- [ ] The changes implement the desired functionality or fix the reported issue.
- [ ] The tests cover the new changes and pass successfully.
- [ ] Any potential edge cases or error scenarios have been considered.
